### PR TITLE
[PR] personalColor 도메인 및 fastApi 연동 기능

### DIFF
--- a/toneup/build.gradle
+++ b/toneup/build.gradle
@@ -26,7 +26,8 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'//웹용
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server' // 앱용
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -40,6 +41,10 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	implementation 'com.corundumstudio.socketio:netty-socketio:2.0.13'
+
+	implementation 'com.google.api-client:google-api-client:2.7.2'
+	implementation 'com.google.oauth-client:google-oauth-client-jetty:1.34.1'
+	implementation 'com.google.http-client:google-http-client-gson:1.43.3'
 
 	//jwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'

--- a/toneup/build.gradle
+++ b/toneup/build.gradle
@@ -45,6 +45,7 @@ dependencies {
 	implementation 'com.google.api-client:google-api-client:2.7.2'
 	implementation 'com.google.oauth-client:google-oauth-client-jetty:1.34.1'
 	implementation 'com.google.http-client:google-http-client-gson:1.43.3'
+	implementation 'com.google.http-client:google-http-client-jackson2:1.43.3'
 
 	//jwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'

--- a/toneup/src/main/java/com/threeboys/toneup/ToneupApplication.java
+++ b/toneup/src/main/java/com/threeboys/toneup/ToneupApplication.java
@@ -4,7 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 
-@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class})
+@SpringBootApplication
 public class ToneupApplication {
 
 	public static void main(String[] args) {

--- a/toneup/src/main/java/com/threeboys/toneup/common/response/exception/ErrorMessages.java
+++ b/toneup/src/main/java/com/threeboys/toneup/common/response/exception/ErrorMessages.java
@@ -1,0 +1,6 @@
+package com.threeboys.toneup.common.response.exception;
+
+public class ErrorMessages {
+    public static final String INVALID_SOCIAL_TOKEN = "Invalid social token";
+    public static final String USER_NOT_FOUND = "User not found";
+}

--- a/toneup/src/main/java/com/threeboys/toneup/common/response/exception/ErrorMessages.java
+++ b/toneup/src/main/java/com/threeboys/toneup/common/response/exception/ErrorMessages.java
@@ -3,4 +3,6 @@ package com.threeboys.toneup.common.response.exception;
 public class ErrorMessages {
     public static final String INVALID_SOCIAL_TOKEN = "Invalid social token";
     public static final String USER_NOT_FOUND = "User not found";
+    public static final String PERSONAL_COLOR_NOT_FOUND = "PersonalColor not found with type: %s";
+
 }

--- a/toneup/src/main/java/com/threeboys/toneup/common/response/exception/GlobalExceptionHandler.java
+++ b/toneup/src/main/java/com/threeboys/toneup/common/response/exception/GlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.threeboys.toneup.common.response.exception;
+
+import com.threeboys.toneup.common.response.StandardResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(InvalidTokenException.class)
+    public ResponseEntity<StandardResponse<Object>> handleInvalidToken(InvalidTokenException ex) {
+        StandardResponse<Object> body = new StandardResponse<>(
+                false, 401, ex.getMessage(), null
+        );
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(body);
+    }
+}

--- a/toneup/src/main/java/com/threeboys/toneup/common/response/exception/InvalidTokenException.java
+++ b/toneup/src/main/java/com/threeboys/toneup/common/response/exception/InvalidTokenException.java
@@ -1,0 +1,7 @@
+package com.threeboys.toneup.common.response.exception;
+
+public class InvalidTokenException extends RuntimeException{
+    public InvalidTokenException(String message) {
+        super(message);
+    }
+}

--- a/toneup/src/main/java/com/threeboys/toneup/controller/AuthController.java
+++ b/toneup/src/main/java/com/threeboys/toneup/controller/AuthController.java
@@ -1,0 +1,37 @@
+package com.threeboys.toneup.controller;
+
+import com.threeboys.toneup.common.response.StandardResponse;
+import com.threeboys.toneup.security.jwt.JWTUtil;
+import com.threeboys.toneup.security.provider.ProviderType;
+import com.threeboys.toneup.security.response.OAuth2LoginRequest;
+import com.threeboys.toneup.security.response.OAuthLoginResponseDTO;
+import com.threeboys.toneup.security.service.GoogleLoginService;
+import com.threeboys.toneup.user.entity.UserEntity;
+import com.threeboys.toneup.user.service.Userservice;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken.Payload;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+
+import java.util.Collections;
+
+@RestController
+@RequestMapping("/api")
+public class AuthController {
+    private final GoogleLoginService googleLoginService;
+
+    public AuthController(Userservice userservice, JWTUtil jwtUtil, @Value("${oauth.google.client-id}") String clientId, GoogleLoginService googleLoginService) {
+
+        this.googleLoginService = googleLoginService;
+    }
+
+    @PostMapping("/oauth2/authorization")
+    public ResponseEntity<?> loginWithGoogle(@RequestBody OAuth2LoginRequest request) {
+       OAuthLoginResponseDTO oAuthLoginResponseDTO = googleLoginService.login(request);
+        return ResponseEntity.ok(new StandardResponse<>(true, 0, "Ok", oAuthLoginResponseDTO));
+    }
+}
+

--- a/toneup/src/main/java/com/threeboys/toneup/controller/AuthController.java
+++ b/toneup/src/main/java/com/threeboys/toneup/controller/AuthController.java
@@ -23,15 +23,13 @@ import java.util.Collections;
 public class AuthController {
     private final GoogleLoginService googleLoginService;
 
-    public AuthController(Userservice userservice, JWTUtil jwtUtil, @Value("${oauth.google.client-id}") String clientId, GoogleLoginService googleLoginService) {
-
+    public AuthController(Userservice userservice, JWTUtil jwtUtil, @Value("${google.client-id}") String clientId, GoogleLoginService googleLoginService) {
         this.googleLoginService = googleLoginService;
     }
 
     @PostMapping("/oauth2/authorization")
     public ResponseEntity<?> loginWithGoogle(@RequestBody OAuth2LoginRequest request) {
-       OAuthLoginResponseDTO oAuthLoginResponseDTO = googleLoginService.login(request);
+        OAuthLoginResponseDTO oAuthLoginResponseDTO = googleLoginService.login(request);
         return ResponseEntity.ok(new StandardResponse<>(true, 0, "Ok", oAuthLoginResponseDTO));
     }
 }
-

--- a/toneup/src/main/java/com/threeboys/toneup/personalColor/config/FastApiConfig.java
+++ b/toneup/src/main/java/com/threeboys/toneup/personalColor/config/FastApiConfig.java
@@ -1,0 +1,22 @@
+package com.threeboys.toneup.personalColor.config;
+
+import com.threeboys.toneup.personalColor.infra.FastApiClient;
+import com.threeboys.toneup.personalColor.infra.FastApiClientImpl;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+
+@Configuration
+@EnableConfigurationProperties(FastApiProperties.class)
+public class FastApiConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+    @Bean
+    public FastApiClient fastApiClient(RestTemplate restTemplate, FastApiProperties props) {
+        return new FastApiClientImpl(restTemplate, props.getUrl());
+    }
+}

--- a/toneup/src/main/java/com/threeboys/toneup/personalColor/config/FastApiProperties.java
+++ b/toneup/src/main/java/com/threeboys/toneup/personalColor/config/FastApiProperties.java
@@ -1,0 +1,17 @@
+package com.threeboys.toneup.personalColor.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@ConfigurationProperties(prefix = "external.fastapi")
+public class FastApiProperties {
+    private String url;
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+}

--- a/toneup/src/main/java/com/threeboys/toneup/personalColor/controller/PersonalColorController.java
+++ b/toneup/src/main/java/com/threeboys/toneup/personalColor/controller/PersonalColorController.java
@@ -1,0 +1,27 @@
+package com.threeboys.toneup.personalColor.controller;
+
+import com.threeboys.toneup.common.response.StandardResponse;
+import com.threeboys.toneup.personalColor.service.PersonalColorService;
+import com.threeboys.toneup.security.CustomOAuth2User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class PersonalColorController {
+
+    private final PersonalColorService personalColorService;
+
+    @PostMapping("/personalcolor")
+    public ResponseEntity<?> createPersonalColor(@RequestPart("image") MultipartFile imageFile, @AuthenticationPrincipal CustomOAuth2User oAuth2User) {
+        Long userId = oAuth2User.getId();
+        String personalColor = personalColorService.updatePersonalColor(userId, imageFile);
+        return ResponseEntity.ok(new StandardResponse<>(true, 0, "Ok", personalColor));
+    }}

--- a/toneup/src/main/java/com/threeboys/toneup/personalColor/domain/PersonalColor.java
+++ b/toneup/src/main/java/com/threeboys/toneup/personalColor/domain/PersonalColor.java
@@ -1,0 +1,21 @@
+package com.threeboys.toneup.personalColor.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Entity
+@Getter
+@RequiredArgsConstructor
+public class PersonalColor {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @Column(name = "type")
+    @Enumerated(EnumType.STRING)
+    private PersonalColorType personalColorType;
+
+}

--- a/toneup/src/main/java/com/threeboys/toneup/personalColor/domain/PersonalColorType.java
+++ b/toneup/src/main/java/com/threeboys/toneup/personalColor/domain/PersonalColorType.java
@@ -1,0 +1,5 @@
+package com.threeboys.toneup.personalColor.domain;
+
+public enum PersonalColorType {
+    SPRING, SUMMER, ATUMN, WINTER
+}

--- a/toneup/src/main/java/com/threeboys/toneup/personalColor/dto/PersonalColorAnalyzeRequest.java
+++ b/toneup/src/main/java/com/threeboys/toneup/personalColor/dto/PersonalColorAnalyzeRequest.java
@@ -1,0 +1,10 @@
+package com.threeboys.toneup.personalColor.dto;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+public class PersonalColorAnalyzeRequest {
+    private final Long userId;
+    private final MultipartFile image;
+}

--- a/toneup/src/main/java/com/threeboys/toneup/personalColor/dto/PersonalColorAnalyzeResponse.java
+++ b/toneup/src/main/java/com/threeboys/toneup/personalColor/dto/PersonalColorAnalyzeResponse.java
@@ -1,0 +1,13 @@
+package com.threeboys.toneup.personalColor.dto;
+
+import com.threeboys.toneup.personalColor.domain.PersonalColorType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@RequiredArgsConstructor
+public class PersonalColorAnalyzeResponse {
+    private final Long userId;
+    private final PersonalColorType personalColor;
+}

--- a/toneup/src/main/java/com/threeboys/toneup/personalColor/exception/PersonalColorNotFoundException.java
+++ b/toneup/src/main/java/com/threeboys/toneup/personalColor/exception/PersonalColorNotFoundException.java
@@ -1,0 +1,10 @@
+package com.threeboys.toneup.personalColor.exception;
+
+import com.threeboys.toneup.common.response.exception.ErrorMessages;
+import com.threeboys.toneup.personalColor.domain.PersonalColorType;
+
+public class PersonalColorNotFoundException extends RuntimeException{
+    public PersonalColorNotFoundException(PersonalColorType colorType) {
+        super(String.format(ErrorMessages.PERSONAL_COLOR_NOT_FOUND, colorType.name()));
+    }
+}

--- a/toneup/src/main/java/com/threeboys/toneup/personalColor/infra/FastApiClient.java
+++ b/toneup/src/main/java/com/threeboys/toneup/personalColor/infra/FastApiClient.java
@@ -1,0 +1,8 @@
+package com.threeboys.toneup.personalColor.infra;
+
+import com.threeboys.toneup.personalColor.dto.PersonalColorAnalyzeRequest;
+import com.threeboys.toneup.personalColor.dto.PersonalColorAnalyzeResponse;
+
+public interface FastApiClient {
+    PersonalColorAnalyzeResponse requestPersonalColorUpdate(PersonalColorAnalyzeRequest input);
+}

--- a/toneup/src/main/java/com/threeboys/toneup/personalColor/infra/FastApiClientImpl.java
+++ b/toneup/src/main/java/com/threeboys/toneup/personalColor/infra/FastApiClientImpl.java
@@ -1,0 +1,30 @@
+package com.threeboys.toneup.personalColor.infra;
+
+import com.threeboys.toneup.personalColor.domain.PersonalColor;
+import com.threeboys.toneup.personalColor.dto.PersonalColorAnalyzeRequest;
+import com.threeboys.toneup.personalColor.dto.PersonalColorAnalyzeResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class FastApiClientImpl implements FastApiClient{
+    private final RestTemplate restTemplate;
+    private final String fastApiUrl;
+    @Override
+    public PersonalColorAnalyzeResponse requestPersonalColorUpdate(PersonalColorAnalyzeRequest input) {
+
+        // FastAPI 호출 (POST 예시)
+        ResponseEntity<PersonalColorAnalyzeResponse> response = restTemplate.postForEntity(
+                fastApiUrl + "/analyze-color", input, PersonalColorAnalyzeResponse.class);
+
+        if (response.getStatusCode() != HttpStatus.OK) {
+            throw new RuntimeException("FastAPI 호출 실패");
+        }
+
+        return response.getBody();
+    }
+}

--- a/toneup/src/main/java/com/threeboys/toneup/personalColor/repository/PersonalColorRepository.java
+++ b/toneup/src/main/java/com/threeboys/toneup/personalColor/repository/PersonalColorRepository.java
@@ -1,0 +1,12 @@
+package com.threeboys.toneup.personalColor.repository;
+
+import com.threeboys.toneup.personalColor.domain.PersonalColor;
+import com.threeboys.toneup.personalColor.domain.PersonalColorType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PersonalColorRepository extends JpaRepository<PersonalColor, Integer> {
+
+    Optional<PersonalColor> findByPersonalColorType(PersonalColorType personalColorType);
+}

--- a/toneup/src/main/java/com/threeboys/toneup/personalColor/service/PersonalColorService.java
+++ b/toneup/src/main/java/com/threeboys/toneup/personalColor/service/PersonalColorService.java
@@ -1,0 +1,49 @@
+package com.threeboys.toneup.personalColor.service;
+
+import com.threeboys.toneup.personalColor.domain.PersonalColor;
+import com.threeboys.toneup.personalColor.dto.PersonalColorAnalyzeRequest;
+import com.threeboys.toneup.personalColor.dto.PersonalColorAnalyzeResponse;
+import com.threeboys.toneup.personalColor.exception.PersonalColorNotFoundException;
+import com.threeboys.toneup.personalColor.infra.FastApiClient;
+import com.threeboys.toneup.personalColor.repository.PersonalColorRepository;
+import com.threeboys.toneup.user.entity.UserEntity;
+import com.threeboys.toneup.user.exception.UserNotFoundException;
+import com.threeboys.toneup.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class PersonalColorService {
+    private final FastApiClient fastApiClient;
+    private final UserRepository userRepository;
+    private final PersonalColorRepository personalColorRepository;
+
+
+    @Transactional
+    public String updatePersonalColor(Long userId, MultipartFile image) {
+        // 1. 유저 조회
+        UserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+
+        // 2. FastAPI 요청 객체 생성
+        PersonalColorAnalyzeRequest request = new PersonalColorAnalyzeRequest(userEntity.getId(), image);
+
+        // 3. FastAPI 결과 받아서 도메인 객체 생성
+        PersonalColorAnalyzeResponse personalColor = fastApiClient.requestPersonalColorUpdate(request);
+
+        // 4. 퍼스널컬러 영속 엔티티 조회 (연관관계용)
+        PersonalColor colorEntity = personalColorRepository.findByPersonalColorType(personalColor.getPersonalColor())
+                .orElseThrow(() -> new PersonalColorNotFoundException(personalColor.getPersonalColor()));
+
+        // 5. 유저에 퍼스널컬러 반영 (User 도메인에서 처리)
+        userEntity.updatePersonalColor(colorEntity);
+        return personalColor.getPersonalColor().name();
+    }
+
+
+
+}

--- a/toneup/src/main/java/com/threeboys/toneup/security/config/GoogleApiConfig.java
+++ b/toneup/src/main/java/com/threeboys/toneup/security/config/GoogleApiConfig.java
@@ -1,0 +1,20 @@
+package com.threeboys.toneup.security.config;
+
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.gson.GsonFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GoogleApiConfig {
+
+    @Bean
+    public NetHttpTransport netHttpTransport() {
+        return new NetHttpTransport();
+    }
+    @Bean
+    public JsonFactory jsonFactory() {
+        return GsonFactory.getDefaultInstance();
+    }
+}

--- a/toneup/src/main/java/com/threeboys/toneup/security/config/SecurityConfig.java
+++ b/toneup/src/main/java/com/threeboys/toneup/security/config/SecurityConfig.java
@@ -6,16 +6,23 @@ import com.threeboys.toneup.security.jwt.JWTUtil;
 import com.threeboys.toneup.security.service.CustomOAuth2UserService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtDecoders;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+    @Bean
+    public JwtDecoder jwtDecoder() {
+        return JwtDecoders.fromIssuerLocation("https://accounts.google.com");
+    }
     private final CustomOAuth2UserService customOAuth2UserService;
     private final Oauth2SuccessHandler oauth2SuccessHandler;
     private final JWTUtil jwtUtil;
@@ -49,14 +56,15 @@ public class SecurityConfig {
                 .oauth2Login((oauth2)->oauth2
                         .userInfoEndpoint((userInfoEndpointConfig)->userInfoEndpointConfig
                             .userService(customOAuth2UserService))
-                        .successHandler(oauth2SuccessHandler)
-                );
+                        .successHandler(oauth2SuccessHandler));
 
         //경로별 인가 작업
         http
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers("/").permitAll()
+                        .requestMatchers("/api/api/**").authenticated()
                         .anyRequest().authenticated());
+//                        .anyRequest().denyAll();
 
         //세션 설정 : STATELESS
         http

--- a/toneup/src/main/java/com/threeboys/toneup/security/handler/Oauth2SuccessHandler.java
+++ b/toneup/src/main/java/com/threeboys/toneup/security/handler/Oauth2SuccessHandler.java
@@ -14,11 +14,13 @@ import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
 
+@Component
 public class Oauth2SuccessHandler implements AuthenticationSuccessHandler {
     private final JWTUtil jwtUtil;
 

--- a/toneup/src/main/java/com/threeboys/toneup/security/handler/Oauth2SuccessHandler.java
+++ b/toneup/src/main/java/com/threeboys/toneup/security/handler/Oauth2SuccessHandler.java
@@ -5,10 +5,12 @@ import com.threeboys.toneup.common.response.StandardResponse;
 import com.threeboys.toneup.security.CustomOAuth2User;
 import com.threeboys.toneup.security.jwt.JWTUtil;
 import com.threeboys.toneup.security.response.OAuthLoginResponseDTO;
+import com.threeboys.toneup.user.entity.UserEntity;
+import com.threeboys.toneup.user.repository.UserRepository;
+import com.threeboys.toneup.user.service.Userservice;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
@@ -23,9 +25,13 @@ import java.util.Iterator;
 @Component
 public class Oauth2SuccessHandler implements AuthenticationSuccessHandler {
     private final JWTUtil jwtUtil;
+    private final Userservice userservice;
+    private final UserRepository userRepository;
 
-    public Oauth2SuccessHandler(JWTUtil jwtUtil) {
+    public Oauth2SuccessHandler(JWTUtil jwtUtil, Userservice userservice, UserRepository userRepository) {
         this.jwtUtil = jwtUtil;
+        this.userservice = userservice;
+        this.userRepository = userRepository;
     }
 
     @Override
@@ -43,15 +49,16 @@ public class Oauth2SuccessHandler implements AuthenticationSuccessHandler {
 
         String accessToken = jwtUtil.createJwt(userId,nickname, personalColor, role, 60*60*60L);
         String refreshToken = jwtUtil.createRefreshJwt(userId, 60*60*24*14L);
-
-        OAuthLoginResponseDTO data = new OAuthLoginResponseDTO();
-        data.setProvider(privider);
-        data.setPersonal(false); // 필요에 따라 변경
-        data.setSignedUp(true);  // 필요에 따라 변경
-        data.setNickname(nickname);
-        data.setUserId(userId);
-        data.setAccessToken(accessToken);
-        data.setRefreshToken(refreshToken);
+        UserEntity socialUser = userRepository.findById(userId).orElseThrow();
+        OAuthLoginResponseDTO data = OAuthLoginResponseDTO.builder()
+                .provider(privider)
+                .nickname(nickname)
+                .userId(userId)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .isSignedUp(userservice.isSignedUp(socialUser))
+                .isPersonal(userservice.isPersonal(socialUser))
+                .build();
 
         StandardResponse<OAuthLoginResponseDTO> responseBody = new StandardResponse<>(true, 0, "Ok", data);
 

--- a/toneup/src/main/java/com/threeboys/toneup/security/jwt/JwtConstants.java
+++ b/toneup/src/main/java/com/threeboys/toneup/security/jwt/JwtConstants.java
@@ -1,0 +1,6 @@
+package com.threeboys.toneup.security.jwt;
+
+public class JwtConstants {
+    public static final long ACCESS_TOKEN_EXPIRATION = 60 * 60 * 60L; // 60시간
+    public static final long REFRESH_TOKEN_EXPIRATION = 60 * 60 * 24 * 30L; // 30일
+}

--- a/toneup/src/main/java/com/threeboys/toneup/security/response/OAuth2LoginRequest.java
+++ b/toneup/src/main/java/com/threeboys/toneup/security/response/OAuth2LoginRequest.java
@@ -1,0 +1,12 @@
+package com.threeboys.toneup.security.response;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class OAuth2LoginRequest {
+    private String provider;
+    private String token;
+
+}

--- a/toneup/src/main/java/com/threeboys/toneup/security/response/OAuthLoginResponseDTO.java
+++ b/toneup/src/main/java/com/threeboys/toneup/security/response/OAuthLoginResponseDTO.java
@@ -1,8 +1,10 @@
 package com.threeboys.toneup.security.response;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
+@Builder
 @Getter
 @Setter
 public class OAuthLoginResponseDTO {

--- a/toneup/src/main/java/com/threeboys/toneup/security/service/CustomOAuth2UserService.java
+++ b/toneup/src/main/java/com/threeboys/toneup/security/service/CustomOAuth2UserService.java
@@ -9,6 +9,7 @@ import com.threeboys.toneup.user.domain.User;
 import com.threeboys.toneup.user.dto.UserDTO;
 import com.threeboys.toneup.user.entity.UserEntity;
 import com.threeboys.toneup.user.repository.UserRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
@@ -16,7 +17,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
-
+@Slf4j
 @Service
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private final UserRepository userRepository;
@@ -29,9 +30,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
 
         OAuth2User oAuth2User = super.loadUser(userRequest);
-
-        System.out.println(oAuth2User);
-
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
         OAuth2Response oAuth2Response = null;
         if (registrationId.equals("naver")) {

--- a/toneup/src/main/java/com/threeboys/toneup/security/service/CustomOAuth2UserService.java
+++ b/toneup/src/main/java/com/threeboys/toneup/security/service/CustomOAuth2UserService.java
@@ -65,7 +65,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                     return userRepository.save(newUser);
                 });
 
-        UserDTO userDTO = UserDTO.of(socialUser.getId(), name, nickname, socialUser.getPersonalColorId(), socialUser.getRole(), socialUser.getProvider().toString());
+        UserDTO userDTO = UserDTO.of(socialUser.getId(), name, nickname, socialUser.getPersonalColor().getPersonalColorType().toString(), socialUser.getRole(), socialUser.getProvider().toString());
         return new CustomOAuth2User(userDTO);
 
     }

--- a/toneup/src/main/java/com/threeboys/toneup/security/service/GoogleLoginService.java
+++ b/toneup/src/main/java/com/threeboys/toneup/security/service/GoogleLoginService.java
@@ -1,0 +1,85 @@
+package com.threeboys.toneup.security.service;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.threeboys.toneup.common.response.exception.ErrorMessages;
+import com.threeboys.toneup.common.response.exception.InvalidTokenException;
+import com.threeboys.toneup.security.jwt.JWTUtil;
+import com.threeboys.toneup.security.jwt.JwtConstants;
+import com.threeboys.toneup.security.provider.ProviderType;
+import com.threeboys.toneup.security.response.OAuth2LoginRequest;
+import com.threeboys.toneup.security.response.OAuthLoginResponseDTO;
+import com.threeboys.toneup.user.entity.UserEntity;
+import com.threeboys.toneup.user.repository.UserRepository;
+import com.threeboys.toneup.user.service.Userservice;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Collections;
+import java.util.Optional;
+
+public class GoogleLoginService implements SocialLoginService{
+    private final Userservice userservice;
+    private final JWTUtil jwtUtil;
+    private final GoogleIdTokenVerifier verifier;
+
+    @Value("${google.client-id}")
+    private String clientId;
+
+    public GoogleLoginService(UserRepository userRepository, Userservice userservice, JWTUtil jwtUtil,
+                              NetHttpTransport transport, JsonFactory jsonFactory, String clientId) {
+        this.userservice = userservice;
+        this.clientId = clientId;
+        this.jwtUtil = jwtUtil;
+        // Google ID 토큰 검증기 생성
+        this.verifier = new GoogleIdTokenVerifier.Builder(transport, jsonFactory)
+                .setAudience(Collections.singletonList(this.clientId))
+                .build();
+    }
+
+
+    @Override
+    public OAuthLoginResponseDTO login(OAuth2LoginRequest request) {
+
+
+        try {
+            // 2. ID 토큰 검증
+            GoogleIdToken idToken = Optional.ofNullable(verifier.verify(request.getToken()))
+                    .orElseThrow(() -> new InvalidTokenException(ErrorMessages.INVALID_SOCIAL_TOKEN));
+
+            GoogleIdToken.Payload payload = idToken.getPayload();
+            String email = payload.getEmail();
+            String name = (String) payload.get("name");
+            ProviderType providerType = ProviderType.valueOf(request.getProvider().toUpperCase());
+            String providerId =  payload.getSubject();
+            String nickname = name+"_"+providerId;
+
+            // 3. (예시) 회원 가입 또는 로그인 처리 (생략 가능)
+            UserEntity socialUser = userservice.registerUser(name,nickname, email, providerType, providerId);
+
+            String accessToken = jwtUtil.createJwt(socialUser.getId(), socialUser.getNickname(), socialUser.getPersonalColorId(), socialUser.getRole(), JwtConstants.ACCESS_TOKEN_EXPIRATION);
+            String refreshToken = jwtUtil.createRefreshJwt(socialUser.getId(), JwtConstants.REFRESH_TOKEN_EXPIRATION);
+
+            OAuthLoginResponseDTO dto =OAuthLoginResponseDTO.builder()
+                    .provider(providerType.name())
+                    .nickname(nickname)
+                    .userId(socialUser.getId())
+                    .accessToken(accessToken)
+                    .refreshToken(refreshToken)
+                    .isSignedUp(userservice.isSignedUp(socialUser))
+                    .isPersonal(userservice.isPersonal(socialUser))
+                    .build();
+            return dto;
+        } catch (GeneralSecurityException | IOException e) {
+            throw new InvalidTokenException("INVALID_SOCIAL_TOKEN");
+        }
+    }
+
+    @Override
+    public ProviderType getProviderType() {
+        return ProviderType.GOOGLE;
+    }
+}

--- a/toneup/src/main/java/com/threeboys/toneup/security/service/GoogleLoginService.java
+++ b/toneup/src/main/java/com/threeboys/toneup/security/service/GoogleLoginService.java
@@ -15,12 +15,13 @@ import com.threeboys.toneup.user.entity.UserEntity;
 import com.threeboys.toneup.user.repository.UserRepository;
 import com.threeboys.toneup.user.service.Userservice;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Collections;
 import java.util.Optional;
-
+@Service
 public class GoogleLoginService implements SocialLoginService{
     private final Userservice userservice;
     private final JWTUtil jwtUtil;
@@ -30,9 +31,9 @@ public class GoogleLoginService implements SocialLoginService{
     private String clientId;
 
     public GoogleLoginService(UserRepository userRepository, Userservice userservice, JWTUtil jwtUtil,
-                              NetHttpTransport transport, JsonFactory jsonFactory, String clientId) {
+                              NetHttpTransport transport, JsonFactory jsonFactory) {
         this.userservice = userservice;
-        this.clientId = clientId;
+//        this.clientId = clientId;
         this.jwtUtil = jwtUtil;
         // Google ID 토큰 검증기 생성
         this.verifier = new GoogleIdTokenVerifier.Builder(transport, jsonFactory)
@@ -60,7 +61,7 @@ public class GoogleLoginService implements SocialLoginService{
             // 3. (예시) 회원 가입 또는 로그인 처리 (생략 가능)
             UserEntity socialUser = userservice.registerUser(name,nickname, email, providerType, providerId);
 
-            String accessToken = jwtUtil.createJwt(socialUser.getId(), socialUser.getNickname(), socialUser.getPersonalColorId(), socialUser.getRole(), JwtConstants.ACCESS_TOKEN_EXPIRATION);
+            String accessToken = jwtUtil.createJwt(socialUser.getId(), socialUser.getNickname(), socialUser.getPersonalColor().getPersonalColorType().toString(), socialUser.getRole(), JwtConstants.ACCESS_TOKEN_EXPIRATION);
             String refreshToken = jwtUtil.createRefreshJwt(socialUser.getId(), JwtConstants.REFRESH_TOKEN_EXPIRATION);
 
             OAuthLoginResponseDTO dto =OAuthLoginResponseDTO.builder()

--- a/toneup/src/main/java/com/threeboys/toneup/security/service/SocialLoginService.java
+++ b/toneup/src/main/java/com/threeboys/toneup/security/service/SocialLoginService.java
@@ -1,0 +1,10 @@
+package com.threeboys.toneup.security.service;
+
+import com.threeboys.toneup.security.provider.ProviderType;
+import com.threeboys.toneup.security.response.OAuth2LoginRequest;
+import com.threeboys.toneup.security.response.OAuthLoginResponseDTO;
+
+public interface SocialLoginService {
+    OAuthLoginResponseDTO login(OAuth2LoginRequest request);
+    ProviderType getProviderType();
+}

--- a/toneup/src/main/java/com/threeboys/toneup/user/domain/User.java
+++ b/toneup/src/main/java/com/threeboys/toneup/user/domain/User.java
@@ -87,7 +87,7 @@ public class User {
     }
 
     public static User fromEntity(UserEntity entity) {
-        return new User(entity.getName(),  entity.getEmail(), entity.getRole(), entity.getNickname(),entity.getPersonalColorId(),entity.getBio(),entity.getProfileImageId());
+        return new User(entity.getName(),  entity.getEmail(), entity.getRole(), entity.getNickname(),entity.getPersonalColor().getPersonalColorType().toString(),entity.getBio(),entity.getProfileImageId());
     }
 
 //    public UserEntity toEntity() {

--- a/toneup/src/main/java/com/threeboys/toneup/user/entity/UserEntity.java
+++ b/toneup/src/main/java/com/threeboys/toneup/user/entity/UserEntity.java
@@ -53,6 +53,10 @@ public class UserEntity {
         this.bio ="안녕하세요!";
     }
 
+    public UserEntity() {
+
+    }
+
     public User toDomain() {
         return User.fromEntity(this);
     }

--- a/toneup/src/main/java/com/threeboys/toneup/user/entity/UserEntity.java
+++ b/toneup/src/main/java/com/threeboys/toneup/user/entity/UserEntity.java
@@ -1,5 +1,6 @@
 package com.threeboys.toneup.user.entity;
 
+import com.threeboys.toneup.personalColor.domain.PersonalColor;
 import com.threeboys.toneup.security.provider.ProviderType;
 import com.threeboys.toneup.user.domain.User;
 import jakarta.persistence.*;
@@ -33,9 +34,9 @@ public class UserEntity {
 //    @JoinColumn(name = "profile_image_id")
     private String profileImageId;
 
-//        @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "personal_color_id")
-    private String personalColorId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "personal_color_id")
+    private PersonalColor personalColor;
 
     @Column(nullable = false)
     private String role;
@@ -61,4 +62,7 @@ public class UserEntity {
         return User.fromEntity(this);
     }
 
+    public void updatePersonalColor(PersonalColor personalColor) {
+        this.personalColor = personalColor;
+    }
 }

--- a/toneup/src/main/java/com/threeboys/toneup/user/exception/UserNotFoundException.java
+++ b/toneup/src/main/java/com/threeboys/toneup/user/exception/UserNotFoundException.java
@@ -1,0 +1,9 @@
+package com.threeboys.toneup.user.exception;
+
+import com.threeboys.toneup.common.response.exception.ErrorMessages;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(Long userId) {
+        super(String.format(ErrorMessages.USER_NOT_FOUND, userId));
+    }
+}

--- a/toneup/src/main/java/com/threeboys/toneup/user/repository/UserRepository.java
+++ b/toneup/src/main/java/com/threeboys/toneup/user/repository/UserRepository.java
@@ -1,12 +1,13 @@
 package com.threeboys.toneup.user.repository;
 
 import com.threeboys.toneup.security.provider.ProviderType;
-import com.threeboys.toneup.user.domain.User;
 import com.threeboys.toneup.user.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface UserRepository extends JpaRepository<UserEntity,Long> {
     Optional<UserEntity> findByEmail(String mail);
     Optional<UserEntity> findByProviderAndProviderId(ProviderType provider, String providerId);

--- a/toneup/src/main/java/com/threeboys/toneup/user/service/Userservice.java
+++ b/toneup/src/main/java/com/threeboys/toneup/user/service/Userservice.java
@@ -28,7 +28,7 @@ public class Userservice {
 
 
     public boolean isPersonal(UserEntity user) {
-        return user.getPersonalColorId() != null;
+        return user.getPersonalColor().getPersonalColorType() != null;
     }
 
     public boolean isSignedUp(UserEntity user) {

--- a/toneup/src/main/java/com/threeboys/toneup/user/service/Userservice.java
+++ b/toneup/src/main/java/com/threeboys/toneup/user/service/Userservice.java
@@ -1,0 +1,38 @@
+package com.threeboys.toneup.user.service;
+
+import com.threeboys.toneup.security.provider.ProviderType;
+import com.threeboys.toneup.user.entity.UserEntity;
+import com.threeboys.toneup.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class Userservice {
+    private final UserRepository userRepository;
+
+    public UserEntity registerUser(String name, String nickname, String email, ProviderType providerType, String providerId){
+        return userRepository.findByProviderAndProviderId(providerType,providerId)
+                .map(userEntity -> {
+                    // 정보 업데이트
+                    userEntity.setName(name);
+                    userEntity.setEmail(email);
+                    return userRepository.save(userEntity);
+                })
+                .orElseGet(() -> {
+                    // 회원가입
+                    UserEntity newUser = new UserEntity(name,nickname, providerType, providerId, email);
+                    return userRepository.save(newUser);
+                });
+    }
+
+
+    public boolean isPersonal(UserEntity user) {
+        return user.getPersonalColorId() != null;
+    }
+
+    public boolean isSignedUp(UserEntity user) {
+        return user.getId() != null;
+    }
+
+}

--- a/toneup/src/main/resources/application.yml
+++ b/toneup/src/main/resources/application.yml
@@ -7,3 +7,8 @@ socketio:
   server:
     hostname: "localhost"
     port: 8081
+server:
+  servlet:
+    encoding:
+      force-response: true
+

--- a/toneup/src/test/java/com/threeboys/toneup/security/OAuth2UserServiceTest.java
+++ b/toneup/src/test/java/com/threeboys/toneup/security/OAuth2UserServiceTest.java
@@ -1,14 +1,18 @@
 //package com.threeboys.toneup.security;
 //
+//import com.threeboys.toneup.security.provider.ProviderType;
 //import com.threeboys.toneup.security.service.CustomOAuth2UserService;
 //import com.threeboys.toneup.user.domain.User;
+//import com.threeboys.toneup.user.entity.UserEntity;
 //import com.threeboys.toneup.user.repository.UserRepository;
+//import org.junit.jupiter.api.BeforeEach;
 //import org.junit.jupiter.api.Test;
 //import org.junit.jupiter.api.extension.ExtendWith;
 //import org.mockito.InjectMocks;
 //import org.mockito.Mock;
 //import org.mockito.junit.jupiter.MockitoExtension;
 //import org.springframework.security.oauth2.client.registration.ClientRegistration;
+//import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 //import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 //import org.springframework.security.oauth2.core.user.OAuth2User;
 //
@@ -16,43 +20,58 @@
 //import java.util.Optional;
 //
 //import static org.assertj.core.api.Assertions.assertThat;
+//import static org.junit.jupiter.api.Assertions.assertEquals;
+//import static org.junit.jupiter.api.Assertions.assertNotNull;
 //import static org.mockito.BDDMockito.given;
+//import static org.mockito.Mockito.*;
 //
+//// 단위 테스트
 //@ExtendWith(MockitoExtension.class)
-//class OAuth2UserServiceTest {
-//
-//    @InjectMocks
-//    private CustomOAuth2UserService oAuth2UserService;
+//class CustomOAuth2UserServiceTest {
 //
 //    @Mock
 //    private UserRepository userRepository;
 //
 //    @Mock
-//    private OAuth2UserRequest userRequest;
+//    private DefaultOAuth2UserService defaultOAuth2UserService;
+//    private CustomOAuth2UserService oAuth2UserService;
 //
-//    @Mock
-//    private ClientRegistration clientRegistration;
-//    @Mock
-//    private OAuth2User oauth2User;
+//    @BeforeEach
+//    void setup() {
+//        oAuth2UserService = new CustomOAuth2UserService(userRepository);
+//    }
 //
 //    @Test
-//    void returns_existing_user() {
-//        // given
-//        User existUser = new User("test");
+//    void testProcessOAuth2User_existingUser() {
+//        OAuth2UserRequest mockRequest = mock(OAuth2UserRequest.class);
+//        OAuth2User mockOAuth2User = mock(OAuth2User.class);
 //
-//        given(oauth2User.getAttributes()).willReturn(Map.of(
-//                "email", "test@example.com",
-//                "name", "테스트유저"
-//        ));
+//        when(defaultOAuth2UserService.loadUser(mockRequest)).thenReturn(mockOAuth2User);
+//        when(mockOAuth2User.getAttribute("providerType")).thenReturn("google");
+//        when(mockOAuth2User.getAttribute("providerId")).thenReturn("1234");
+//        UserEntity newUser = new UserEntity("김준용","김준용_1234", ProviderType.GOOGLE, "1234", "test@test.com");
+//        ProviderType providerType = ProviderType.GOOGLE;
+//        when(userRepository.findByProviderAndProviderId(providerType,"1234")).thenReturn(Optional.of(newUser));
 //
-//        given(userRequest.getClientRegistration()).willReturn(clientRegistration);
-//        given(clientRegistration.getRegistrationId()).willReturn("google");
-//        given(userRepository.findByEmail("test@example.com")).willReturn(Optional.of(existUser));
+//        OAuth2User result = oAuth2UserService.loadUser(mockRequest);
 //
-//        // when
-//        OAuth2User user = oAuth2UserService.loadUser(userRequest);
+//        assertNotNull(result);
+//        verify(userRepository, never()).save(any());
+//    }
+
+//    @Test
+//    void testProcessOAuth2User_newUser() {
+//        OAuth2User mockOAuth2User = mock(OAuth2User.class);
+//        when(mockOAuth2User.getAttribute("email")).thenReturn("new@example.com");
 //
-//        // then
-//        assertThat(user.getName()).isEqualTo("test@example.com");
+//        when(userRepository.findByEmail("new@example.com")).thenReturn(Optional.empty());
+//
+//        User newUser = new User("new@example.com");
+//        when(userRepository.save(any(User.class))).thenReturn(newUser);
+//
+//        User result = oAuth2UserService.processOAuth2User(mockOAuth2User);
+//
+//        assertEquals(newUser, result);
+//        verify(userRepository).save(any(User.class));
 //    }
 //}


### PR DESCRIPTION
## 🔍 변경점
- personalColor 도메인 퍼스널컬러 이미지 분석 요청 기능 추가
- fastApi post 요청 부분 추가
- 구글 로그인 설정 빈 추가
- personalColor 도메인 추가에 따른 유저 도메인 수정
## 문제점

## 개선점

- Oauth2 로그인 부분 리팩토링 필요
- 예외 글로벌 도메인 나누기

## ✅ PR 유형

- [X]  새로운 기능 추가
- [X]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [X]  코드 리팩토링
- [ ]  문서 수정
- [ ]  테스트 코드, 리팩토링 테스트 코드 추가
- [X]  파일 혹은 폴더명 수정
- [ ]  파일 삭제
- [X]  설정 파일 수정 및 추가
- [ ]  이미지나 동영상 추가
