### PR TITLE
[PR] feed 추가 요청 api 기능 구현

### DIFF
--- a/toneup/src/main/java/com/threeboys/toneup/chat/domain/ChatRoomUser.java
+++ b/toneup/src/main/java/com/threeboys/toneup/chat/domain/ChatRoomUser.java
@@ -9,8 +9,8 @@ public class ChatRoomUser {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
+    @ManyToOne(fetch = FetchType.LAZY)
     private UserEntity userId;
 
     @JoinColumn(name = "chatRoom_id")

--- a/toneup/src/main/java/com/threeboys/toneup/common/controller/FeedController.java
+++ b/toneup/src/main/java/com/threeboys/toneup/common/controller/FeedController.java
@@ -1,0 +1,29 @@
+package com.threeboys.toneup.common.controller;
+
+import com.threeboys.toneup.common.response.PresignedUrlListResponseDTO;
+import com.threeboys.toneup.common.response.StandardResponse;
+import com.threeboys.toneup.feed.dto.FeedRequest;
+import com.threeboys.toneup.feed.dto.FeedResponse;
+import com.threeboys.toneup.feed.service.FeedService;
+import com.threeboys.toneup.security.CustomOAuth2User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class FeedController {
+    private final FeedService feedService;
+
+    @PostMapping("/feeds")
+    public ResponseEntity<?> createFeed(@RequestBody FeedRequest feedRequest, @AuthenticationPrincipal CustomOAuth2User customOAuth2User){
+        Long userId = customOAuth2User.getId();
+        FeedResponse feedResponse = feedService.createFeed(userId, feedRequest);
+        return ResponseEntity.ok(new StandardResponse<>(true, 0, "ok",feedResponse));
+    }
+}

--- a/toneup/src/main/java/com/threeboys/toneup/common/domain/ImageRepository.java
+++ b/toneup/src/main/java/com/threeboys/toneup/common/domain/ImageRepository.java
@@ -1,0 +1,8 @@
+package com.threeboys.toneup.common.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ImageRepository extends JpaRepository<Images, Long> {
+}

--- a/toneup/src/main/java/com/threeboys/toneup/common/domain/ImageType.java
+++ b/toneup/src/main/java/com/threeboys/toneup/common/domain/ImageType.java
@@ -1,0 +1,5 @@
+package com.threeboys.toneup.common.domain;
+
+public enum ImageType {
+    PRODUCT,  FEED,  DIARY, CHAT, PROFILE
+}

--- a/toneup/src/main/java/com/threeboys/toneup/common/domain/Images.java
+++ b/toneup/src/main/java/com/threeboys/toneup/common/domain/Images.java
@@ -1,0 +1,30 @@
+package com.threeboys.toneup.common.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+
+@Entity
+//@NoArgsConstructor
+public class Images {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long refId;
+    private String url;
+
+    @Enumerated(EnumType.STRING)
+    private ImageType type;
+    private int ImageOrder;
+    private String s3Key;
+
+    @Builder
+    public Images(Long refId, String url, ImageType type, int order, String s3Key) {
+        this.refId = refId;
+        this.url = url;
+        this.type = type;
+        this.ImageOrder = order;
+        this.s3Key = s3Key;
+    }
+}

--- a/toneup/src/main/java/com/threeboys/toneup/feed/domain/Feed.java
+++ b/toneup/src/main/java/com/threeboys/toneup/feed/domain/Feed.java
@@ -1,17 +1,21 @@
 package com.threeboys.toneup.feed.domain;
 
+import com.threeboys.toneup.common.domain.ImageType;
+import com.threeboys.toneup.common.domain.Images;
 import com.threeboys.toneup.feed.exception.InvalidContentLengthException;
 import com.threeboys.toneup.feed.exception.InvalidImageCountException;
 import com.threeboys.toneup.user.entity.UserEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 //@AllArgsConstructor
 @NoArgsConstructor
 @Entity
+@Getter
 public class Feed {
     private static final int MAX_CONTENT_LENGTH = 1000;
     private static final int MAX_IMAGE_SIZE = 5;
@@ -26,8 +30,9 @@ public class Feed {
     private UserEntity userId;
 
     private String content;
+
     @Transient
-    private List<String> imageUrls;
+    private List<Images> imageUrlList = new ArrayList<>();
 
     @Builder
     public Feed(UserEntity user , String content){
@@ -36,9 +41,19 @@ public class Feed {
         this.content = content;
     }
 
-    public void attchImages(List<String> imageUrls){
+    public void attachImages(List<String> imageUrls){
         validateImageCount(imageUrls);
-        this.imageUrls = imageUrls;
+        for(int i =0; i< imageUrls.size(); i++){
+            Images images = Images.builder()
+                    .type(ImageType.FEED)
+                    .refId(id)
+                    .url(imageUrls.get(i))
+                    .order(i)
+                    .s3Key(imageUrls.get(i))
+                    .build();
+            imageUrlList.add(images);
+        }
+
     }
 
     private void validateImageCount(List<String> imageUrls){

--- a/toneup/src/main/java/com/threeboys/toneup/feed/dto/FeedRequest.java
+++ b/toneup/src/main/java/com/threeboys/toneup/feed/dto/FeedRequest.java
@@ -1,0 +1,13 @@
+package com.threeboys.toneup.feed.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class FeedRequest {
+    private String content;
+    private List<String> imageUrls;
+}

--- a/toneup/src/main/java/com/threeboys/toneup/feed/dto/FeedResponse.java
+++ b/toneup/src/main/java/com/threeboys/toneup/feed/dto/FeedResponse.java
@@ -1,0 +1,10 @@
+package com.threeboys.toneup.feed.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class FeedResponse {
+    private Long feedId;
+}

--- a/toneup/src/main/java/com/threeboys/toneup/feed/repository/FeedRepository.java
+++ b/toneup/src/main/java/com/threeboys/toneup/feed/repository/FeedRepository.java
@@ -1,0 +1,9 @@
+package com.threeboys.toneup.feed.repository;
+
+import com.threeboys.toneup.feed.domain.Feed;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FeedRepository extends JpaRepository<Feed, Long> {
+}

--- a/toneup/src/main/java/com/threeboys/toneup/feed/service/FeedService.java
+++ b/toneup/src/main/java/com/threeboys/toneup/feed/service/FeedService.java
@@ -1,0 +1,39 @@
+package com.threeboys.toneup.feed.service;
+
+import com.threeboys.toneup.common.domain.ImageRepository;
+import com.threeboys.toneup.feed.domain.Feed;
+import com.threeboys.toneup.feed.dto.FeedRequest;
+import com.threeboys.toneup.feed.dto.FeedResponse;
+import com.threeboys.toneup.feed.repository.FeedRepository;
+import com.threeboys.toneup.user.entity.UserEntity;
+import com.threeboys.toneup.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FeedService {
+    private final FeedRepository feedRepository;
+    private final UserRepository userRepository;
+    private final ImageRepository imageRepository;
+
+    @Transactional
+    public FeedResponse createFeed(Long userId, FeedRequest feedRequest){
+        UserEntity user = userRepository.getReferenceById(userId);
+        String content = feedRequest.getContent();
+        List<String> imageUrls = feedRequest.getImageUrls();
+
+        Feed feed  = new Feed(user, content);
+        //save해서 feed id 받아오기(mysql)
+        feedRepository.save(feed);
+
+        feed.attachImages(imageUrls);
+
+        imageRepository.saveAll(feed.getImageUrlList());
+
+        return new FeedResponse(feed.getId());
+    }
+}

--- a/toneup/src/main/java/com/threeboys/toneup/security/config/SecurityConfig.java
+++ b/toneup/src/main/java/com/threeboys/toneup/security/config/SecurityConfig.java
@@ -62,7 +62,7 @@ public class SecurityConfig {
         //경로별 인가 작업
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/**").permitAll()
+                        .requestMatchers("/").permitAll()
                         .requestMatchers("/api/app/**").authenticated()
                         .anyRequest().authenticated());
 //                        .anyRequest().denyAll();

--- a/toneup/src/main/java/com/threeboys/toneup/security/jwt/JWTFilter.java
+++ b/toneup/src/main/java/com/threeboys/toneup/security/jwt/JWTFilter.java
@@ -25,13 +25,13 @@ public class JWTFilter extends OncePerRequestFilter {
 
         //Header에서 토큰 꺼내기
         String authorizationHeader = request.getHeader("Authorization");
-
         if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
             String token = authorizationHeader.substring(7); // "Bearer " 제거
 
             try {
                 //토큰 유효성 검사, 사용자 정보 추출
                 if (jwtUtil.isValidToken(token)) {
+
                     Long userId = jwtUtil.getUserId(token);
                     String role = jwtUtil.getRole(token);
                     String nickname = jwtUtil.getNickname(token);
@@ -51,6 +51,8 @@ public class JWTFilter extends OncePerRequestFilter {
                 }
 
             } catch (Exception e) {
+                System.out.println(e.getMessage()+"error");
+
                 // 유효하지 않은 토큰일 경우 SecurityContext를 비우고 진행
                 SecurityContextHolder.clearContext();
             }

--- a/toneup/src/main/java/com/threeboys/toneup/security/jwt/JWTUtil.java
+++ b/toneup/src/main/java/com/threeboys/toneup/security/jwt/JWTUtil.java
@@ -34,7 +34,7 @@ public class JWTUtil {
     }
     public Long getUserId(String token) {
 
-        return Long.parseLong(Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("userId", String.class));
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("userId", Long.class);
     }
     public String getPersonalColor(String token) {
 
@@ -51,7 +51,6 @@ public class JWTUtil {
     }
 
     public String createJwt(Long userId, String nickname, String personalColor, String role, Long expiredMs) {
-
         return Jwts.builder()
                 .claim("userId", userId)
                 .claim("nickname", nickname)
@@ -87,7 +86,6 @@ public class JWTUtil {
                     .setSigningKey(secretKey) // 비밀키 설정 (SecretKey 객체)
                     .build()
                     .parseClaimsJws(token);
-
             // 파싱 성공 시 예외 없으므로 토큰은 유효함
             return true;
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {

--- a/toneup/src/main/java/com/threeboys/toneup/user/entity/UserEntity.java
+++ b/toneup/src/main/java/com/threeboys/toneup/user/entity/UserEntity.java
@@ -12,6 +12,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@Table(name = "users")
 public class UserEntity {
 
     @Id

--- a/toneup/src/test/java/com/threeboys/toneup/feed/FeedTest.java
+++ b/toneup/src/test/java/com/threeboys/toneup/feed/FeedTest.java
@@ -4,7 +4,6 @@ import com.threeboys.toneup.feed.domain.Feed;
 import com.threeboys.toneup.feed.exception.InvalidContentLengthException;
 import com.threeboys.toneup.feed.exception.InvalidImageCountException;
 import com.threeboys.toneup.user.entity.UserEntity;
-import com.threeboys.toneup.user.repository.UserRepository;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -40,6 +39,6 @@ public class FeedTest {
                 .content(content)
                 .user(new UserEntity(1L))
                 .build();
-        assertThrows(InvalidImageCountException.class, ()->feed.attchImages(imageUrls));
+        assertThrows(InvalidImageCountException.class, ()->feed.attachImages(imageUrls));
     }
 }

--- a/toneup/src/test/java/com/threeboys/toneup/feed/service/FeedServiceTest.java
+++ b/toneup/src/test/java/com/threeboys/toneup/feed/service/FeedServiceTest.java
@@ -1,0 +1,63 @@
+package com.threeboys.toneup.feed.service;
+
+import com.threeboys.toneup.common.domain.ImageRepository;
+import com.threeboys.toneup.feed.domain.Feed;
+import com.threeboys.toneup.feed.dto.FeedRequest;
+import com.threeboys.toneup.feed.dto.FeedResponse;
+import com.threeboys.toneup.feed.repository.FeedRepository;
+import com.threeboys.toneup.user.entity.UserEntity;
+import com.threeboys.toneup.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FeedServiceTest {
+
+    @InjectMocks
+    private FeedService feedService;
+
+    @Mock
+    private FeedRepository feedRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private ImageRepository imageRepository;
+
+
+    @Test
+    void createFeed() {
+        // given
+        Long userId = 1L;
+        String content = "testContent";
+        List<String> imageUrls = List.of("url1", "url2");
+        FeedRequest feedRequest = new FeedRequest(content, imageUrls);
+        UserEntity user = new UserEntity(userId);
+
+        when(userRepository.getReferenceById(userId)).thenReturn(user);
+
+        when(feedRepository.save(any(Feed.class))).thenAnswer(invocation -> {
+            Feed saved = invocation.getArgument(0);
+            ReflectionTestUtils.setField(saved, "id", 100L); // 실제 서비스 내부 객체에 ID 할당
+            return saved;
+        });
+
+        // when
+        FeedResponse response = feedService.createFeed(userId, feedRequest);
+
+        // then
+        assertThat(response.getFeedId()).isEqualTo(100L);
+    }
+}


### PR DESCRIPTION
## 🔍 변경점
- 피드 작성하기 api 구현
- 이미지 테이블에 삽입 위한 피드별 이미지 ordering 기능 feed 엔티티 내부 attachImage 시 ordering 하도록 구현
- FeedService createFeed 메서드 단위 테스트 추가
 ## 문제점

## 개선점
- image 테이블 s3Key, url 구분해서 저장하는 부분 필요(현재 그냥 s3Key값만 중복 저장중)

## ✅ PR 유형

- [X]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [X]  코드 리팩토링
- [ ]  문서 수정
- [X]  테스트 코드, 리팩토링 테스트 코드 추가
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 삭제
- [ ]  설정 파일 수정 및 추가
- [ ]  이미지나 동영상 추가
