### PR TITLE
[PR] 사용자 본인 Profile 조회 api 기능 구현 컨트롤러, 서비스

### DIFF
--- a/toneup/src/main/java/com/threeboys/toneup/personalColor/domain/PersonalColor.java
+++ b/toneup/src/main/java/com/threeboys/toneup/personalColor/domain/PersonalColor.java
@@ -3,11 +3,12 @@ package com.threeboys.toneup.personalColor.domain;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 
 @Entity
 @Getter
-@RequiredArgsConstructor
+@NoArgsConstructor
 public class PersonalColor {
 
     @Id
@@ -18,4 +19,8 @@ public class PersonalColor {
     @Enumerated(EnumType.STRING)
     private PersonalColorType personalColorType;
 
+    @Builder
+    public PersonalColor(PersonalColorType personalColorType) {
+        this.personalColorType = personalColorType;
+    }
 }

--- a/toneup/src/main/java/com/threeboys/toneup/security/service/GoogleLoginService.java
+++ b/toneup/src/main/java/com/threeboys/toneup/security/service/GoogleLoginService.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Service;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 @Service
 public class GoogleLoginService implements OAuthLoginService{
@@ -27,14 +28,16 @@ public class GoogleLoginService implements OAuthLoginService{
     private final JWTUtil jwtUtil;
     private final GoogleIdTokenVerifier verifier;
 
-    public GoogleLoginService(@Value("${google.client-id}") String clientId, UserRepository userRepository, Userservice userservice, JWTUtil jwtUtil,
+    public GoogleLoginService(@Value("${google.client-id}") String clientId,
+                              @Value("${spring.security.oauth2.client.registration.google.client-id}") String webClientId,
+                              Userservice userservice, JWTUtil jwtUtil,
                               NetHttpTransport transport, JsonFactory jsonFactory) {
         this.userservice = userservice;
 //        this.clientId = clientId;
         this.jwtUtil = jwtUtil;
         // Google ID 토큰 검증기 생성
         this.verifier = new GoogleIdTokenVerifier.Builder(transport, jsonFactory)
-                .setAudience(Collections.singletonList(clientId))
+                .setAudience(List.of(clientId,webClientId))
                 .build();
     }
 

--- a/toneup/src/main/java/com/threeboys/toneup/user/controller/UserController.java
+++ b/toneup/src/main/java/com/threeboys/toneup/user/controller/UserController.java
@@ -1,0 +1,27 @@
+package com.threeboys.toneup.user.controller;
+
+import com.threeboys.toneup.common.response.StandardResponse;
+import com.threeboys.toneup.security.CustomOAuth2User;
+import com.threeboys.toneup.user.dto.ProfileResponse;
+import com.threeboys.toneup.user.service.Userservice;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/profiles")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final Userservice userservice;
+
+    @GetMapping("/me")
+    public ResponseEntity<?> getProfile(@AuthenticationPrincipal CustomOAuth2User customOAuth2User){
+        Long userId = customOAuth2User.getId();
+        ProfileResponse profileResponse = userservice.getProfile(userId);
+        return ResponseEntity.ok(new StandardResponse<>(true, 0, "Ok", profileResponse));
+    }
+}

--- a/toneup/src/main/java/com/threeboys/toneup/user/dto/ProfileResponse.java
+++ b/toneup/src/main/java/com/threeboys/toneup/user/dto/ProfileResponse.java
@@ -1,0 +1,53 @@
+package com.threeboys.toneup.user.dto;
+
+import com.threeboys.toneup.user.entity.UserEntity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+@NoArgsConstructor
+public class ProfileResponse {
+    private Long userId;
+    private String nickname;
+    private String personalColor;
+    private String profileImageUrl;
+    private String bio;
+    private int follower;
+    private int following;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    public ProfileResponse(Long userId, String nickname, String personalColor, String profileImageUrl, String bio, int follower, int following) {
+        this.userId = userId;
+        this.nickname = nickname;
+        this.personalColor = personalColor;
+        this.profileImageUrl = profileImageUrl;
+        this.bio = bio;
+        this.follower = follower;
+        this.following = following;
+    }
+
+    public static ProfileResponse from(UserEntity userEntity, int follower, int following) {
+        return ProfileResponse.builder()
+                .userId(userEntity.getId())
+                .nickname(userEntity.getNickname())
+                .personalColor(userEntity.getPersonalColor().toString())
+                .bio(userEntity.getBio())
+                .follower(follower)
+                .following(following)
+                .build();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof ProfileResponse that)) return false;
+        return follower == that.follower && following == that.following && Objects.equals(userId, that.userId) && Objects.equals(nickname, that.nickname) && Objects.equals(personalColor, that.personalColor) && Objects.equals(profileImageUrl, that.profileImageUrl) && Objects.equals(bio, that.bio);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userId, nickname, personalColor, profileImageUrl, bio, follower, following);
+    }
+}

--- a/toneup/src/main/java/com/threeboys/toneup/user/service/Userservice.java
+++ b/toneup/src/main/java/com/threeboys/toneup/user/service/Userservice.java
@@ -1,7 +1,9 @@
 package com.threeboys.toneup.user.service;
 
 import com.threeboys.toneup.security.provider.ProviderType;
+import com.threeboys.toneup.user.dto.ProfileResponse;
 import com.threeboys.toneup.user.entity.UserEntity;
+import com.threeboys.toneup.user.exception.UserNotFoundException;
 import com.threeboys.toneup.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -35,4 +37,10 @@ public class Userservice {
         return user.getId() != null;
     }
 
+    public ProfileResponse getProfile(Long userId) {
+        UserEntity userEntity = userRepository.findById(userId).orElseThrow(()->new UserNotFoundException(userId));
+        int followerCount = 0 ;// followRepository.countByFolloweeId(userId);
+        int followingCount =0 ;// followRepository.countByFollowerId(userId);
+        return ProfileResponse.from(userEntity,followerCount, followingCount);
+    }
 }

--- a/toneup/src/test/java/com/threeboys/toneup/user/service/UserServiceTest.java
+++ b/toneup/src/test/java/com/threeboys/toneup/user/service/UserServiceTest.java
@@ -1,0 +1,51 @@
+package com.threeboys.toneup.user.service;
+
+import com.threeboys.toneup.feed.domain.Feed;
+import com.threeboys.toneup.personalColor.domain.PersonalColor;
+import com.threeboys.toneup.personalColor.domain.PersonalColorType;
+import com.threeboys.toneup.security.provider.ProviderType;
+import com.threeboys.toneup.user.dto.ProfileResponse;
+import com.threeboys.toneup.user.entity.UserEntity;
+import com.threeboys.toneup.user.exception.UserNotFoundException;
+import com.threeboys.toneup.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+
+    @InjectMocks
+    private Userservice userservice;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("프로필_조회")
+    void getProfile(){
+        UserEntity userEntity = new UserEntity("김준영", "Jjun", ProviderType.GOOGLE, "test1234", "test1234@test.com");
+        userEntity.updatePersonalColor(PersonalColor.builder().personalColorType(PersonalColorType.ATUMN).build());
+        Long userId = 1L;
+        int followerCount = 0 ;// followRepository.countByFolloweeId(userId);
+        int followingCount =0 ;// followRepository.countByFollowerId(userId);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(userEntity));
+        ProfileResponse expectProfileResponse = ProfileResponse.from(userEntity, followerCount, followingCount);
+        ProfileResponse profileResponse = userservice.getProfile(userId);
+
+        assertEquals(expectProfileResponse, profileResponse);
+    }
+}


### PR DESCRIPTION
## 🔍 변경점
-  사용자 본인 Profile 조회 api 기능 구현 컨트롤러, 서비스
- 사용자 본인 Profile 조회 api 기능 구현 테스트
- ios id-token 방식 우회로 web id-token 사용하여 검증

## 문제점

## 개선점

- 프로필 조회 시 following, follower 수 조회 부분 구현 필요(현재 미구현)

## ✅ PR 유형

- [X]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드 리팩토링
- [ ]  문서 수정
- [X]  테스트 코드, 리팩토링 테스트 코드 추가
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 삭제
- [X]  설정 파일 수정 및 추가
- [ ]  이미지나 동영상 추가
