### PR TITLE
[PR] 피드 수정 api 추가

### DIFF
--- a/toneup/src/main/java/com/threeboys/toneup/common/exception/FORBIDDENException.java
+++ b/toneup/src/main/java/com/threeboys/toneup/common/exception/FORBIDDENException.java
@@ -1,0 +1,9 @@
+package com.threeboys.toneup.common.exception;
+
+import com.threeboys.toneup.common.response.exception.ErrorMessages;
+
+public class FORBIDDENException extends RuntimeException {
+    public FORBIDDENException() {
+        super(ErrorMessages.FORBIDDEN);
+    }
+}

--- a/toneup/src/main/java/com/threeboys/toneup/common/repository/ImageRepository.java
+++ b/toneup/src/main/java/com/threeboys/toneup/common/repository/ImageRepository.java
@@ -1,9 +1,22 @@
 package com.threeboys.toneup.common.repository;
 
+import com.threeboys.toneup.common.domain.ImageType;
 import com.threeboys.toneup.common.domain.Images;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ImageRepository extends JpaRepository<Images, Long> {
+
+//    List<Images> findByRefIdOrderByImageOrderAsc(Long refId);
+
+    @Modifying
+    @Query("DELETE FROM Images i WHERE i.type = :type AND i.refId = :refId")
+    void deleteByTypeAndRefId(@Param("type") ImageType type, @Param("refId") Long refId);
 }

--- a/toneup/src/main/java/com/threeboys/toneup/common/response/exception/ErrorMessages.java
+++ b/toneup/src/main/java/com/threeboys/toneup/common/response/exception/ErrorMessages.java
@@ -8,4 +8,6 @@ public class ErrorMessages {
     public static final String INVALID_REFRESH_TOKEN = "유효하지 않은 리프레쉬 토큰입니다.";
     public static final String INVALID_CONTENT_LENGTH = "본문은 최소 1글자 이상 최대 1000자까지 작성 가능합니다.";
     public static final String INVALID_IMAGE_COUNT = "이미지 URL은 최소 1개 이상 최대 5개까지 가능합니다.";
+    public static final String FEED_NOT_FOUND = "수정할 피드를 찾을 수 없습니다.";
+    public static final String FORBIDDEN = "작성자 본인이 아니여서 수정할 권한이 없습니다.";
 }

--- a/toneup/src/main/java/com/threeboys/toneup/feed/controller/FeedController.java
+++ b/toneup/src/main/java/com/threeboys/toneup/feed/controller/FeedController.java
@@ -1,6 +1,5 @@
-package com.threeboys.toneup.common.controller;
+package com.threeboys.toneup.feed.controller;
 
-import com.threeboys.toneup.common.response.PresignedUrlListResponseDTO;
 import com.threeboys.toneup.common.response.StandardResponse;
 import com.threeboys.toneup.feed.dto.FeedRequest;
 import com.threeboys.toneup.feed.dto.FeedResponse;
@@ -9,10 +8,7 @@ import com.threeboys.toneup.security.CustomOAuth2User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,6 +20,13 @@ public class FeedController {
     public ResponseEntity<?> createFeed(@RequestBody FeedRequest feedRequest, @AuthenticationPrincipal CustomOAuth2User customOAuth2User){
         Long userId = customOAuth2User.getId();
         FeedResponse feedResponse = feedService.createFeed(userId, feedRequest);
+        return ResponseEntity.ok(new StandardResponse<>(true, 0, "ok",feedResponse));
+    }
+
+    @PutMapping("/feeds/{feedId}")
+    public ResponseEntity<?> updateFeed(@PathVariable Long feedId, @RequestBody FeedRequest feedRequest, @AuthenticationPrincipal CustomOAuth2User customOAuth2User){
+        Long userId = customOAuth2User.getId();
+        FeedResponse feedResponse = feedService.updateFeed(userId, feedId, feedRequest);
         return ResponseEntity.ok(new StandardResponse<>(true, 0, "ok",feedResponse));
     }
 }

--- a/toneup/src/main/java/com/threeboys/toneup/feed/domain/Feed.java
+++ b/toneup/src/main/java/com/threeboys/toneup/feed/domain/Feed.java
@@ -2,6 +2,7 @@ package com.threeboys.toneup.feed.domain;
 
 import com.threeboys.toneup.common.domain.ImageType;
 import com.threeboys.toneup.common.domain.Images;
+import com.threeboys.toneup.common.exception.FORBIDDENException;
 import com.threeboys.toneup.feed.exception.InvalidContentLengthException;
 import com.threeboys.toneup.feed.exception.InvalidImageCountException;
 import com.threeboys.toneup.user.entity.UserEntity;
@@ -64,6 +65,19 @@ public class Feed {
     private void validateContent(String content) {
         if(content==null|| content.isEmpty() || content.length()>MAX_CONTENT_LENGTH){
             throw new InvalidContentLengthException();
+        }
+    }
+
+    public void changeFeed(String content, List<String> imageUrls) {
+        validateContent(content);
+        validateImageCount(imageUrls);
+        this.content = content;
+        attachImages(imageUrls);
+    }
+
+    public void validateOwner(Long userId) {
+        if (!this.userId.getId().equals(userId)) {
+            throw new FORBIDDENException();
         }
     }
 }

--- a/toneup/src/main/java/com/threeboys/toneup/feed/exception/FeedNotFoundException.java
+++ b/toneup/src/main/java/com/threeboys/toneup/feed/exception/FeedNotFoundException.java
@@ -1,0 +1,9 @@
+package com.threeboys.toneup.feed.exception;
+
+import com.threeboys.toneup.common.response.exception.ErrorMessages;
+
+public class FeedNotFoundException extends RuntimeException {
+    public FeedNotFoundException() {
+        super(ErrorMessages.FEED_NOT_FOUND);
+    }
+}

--- a/toneup/src/main/java/com/threeboys/toneup/feed/service/FeedService.java
+++ b/toneup/src/main/java/com/threeboys/toneup/feed/service/FeedService.java
@@ -1,9 +1,13 @@
 package com.threeboys.toneup.feed.service;
 
+import com.threeboys.toneup.common.domain.ImageType;
+import com.threeboys.toneup.common.domain.Images;
+import com.threeboys.toneup.common.exception.FORBIDDENException;
 import com.threeboys.toneup.common.repository.ImageRepository;
 import com.threeboys.toneup.feed.domain.Feed;
 import com.threeboys.toneup.feed.dto.FeedRequest;
 import com.threeboys.toneup.feed.dto.FeedResponse;
+import com.threeboys.toneup.feed.exception.FeedNotFoundException;
 import com.threeboys.toneup.feed.repository.FeedRepository;
 import com.threeboys.toneup.user.entity.UserEntity;
 import com.threeboys.toneup.user.repository.UserRepository;
@@ -27,13 +31,26 @@ public class FeedService {
         List<String> imageUrls = feedRequest.getImageUrls();
 
         Feed feed  = new Feed(user, content);
+
         //save해서 feed id 받아오기(mysql)
         feedRepository.save(feed);
-
         feed.attachImages(imageUrls);
-
         imageRepository.saveAll(feed.getImageUrlList());
 
         return new FeedResponse(feed.getId());
+    }
+    @Transactional
+    public FeedResponse updateFeed(Long userId, Long feedId,  FeedRequest feedRequest) {
+        Feed feed = feedRepository.findById(feedId).orElseThrow(FeedNotFoundException::new);
+        //작성자인지 검증
+        feed.validateOwner(userId);
+        imageRepository.deleteByTypeAndRefId(ImageType.FEED,feedId);
+
+        //s3 변경된 기존 이미지 삭제 필요? fileService.changeFeedImage
+
+        feed.changeFeed(feedRequest.getContent(), feedRequest.getImageUrls());
+        imageRepository.saveAll(feed.getImageUrlList());
+
+        return new FeedResponse(feedId);
     }
 }

--- a/toneup/src/test/java/com/threeboys/toneup/feed/service/FeedServiceTest.java
+++ b/toneup/src/test/java/com/threeboys/toneup/feed/service/FeedServiceTest.java
@@ -1,23 +1,30 @@
 package com.threeboys.toneup.feed.service;
 
+import com.threeboys.toneup.common.domain.ImageType;
+import com.threeboys.toneup.common.domain.Images;
 import com.threeboys.toneup.common.repository.ImageRepository;
 import com.threeboys.toneup.feed.domain.Feed;
 import com.threeboys.toneup.feed.dto.FeedRequest;
 import com.threeboys.toneup.feed.dto.FeedResponse;
 import com.threeboys.toneup.feed.repository.FeedRepository;
+import com.threeboys.toneup.security.provider.ProviderType;
 import com.threeboys.toneup.user.entity.UserEntity;
 import com.threeboys.toneup.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -56,6 +63,32 @@ class FeedServiceTest {
         FeedResponse response = feedService.createFeed(userId, feedRequest);
 
         // then
+        assertThat(response.getFeedId()).isEqualTo(100L);
+    }
+    @Test
+    @DisplayName("피드 수정하기")
+    void changeFeed(){
+        // given
+        Long feedId = 100L;
+        Long userId = 1L;
+        FeedRequest request = new FeedRequest("새로운 내용", List.of("url1", "url2"));
+        UserEntity user = new UserEntity(userId);
+
+        Feed feed = Mockito.spy(new Feed(user,"기존 내용")); // 변경 전 피드
+
+        given(feedRepository.findById(feedId)).willReturn(Optional.of(feed));
+
+        // when
+        FeedResponse response = feedService.updateFeed(userId, feedId, request);
+
+        // then
+        // feed 내용 변경 확인
+        verify(feed).changeFeed("새로운 내용", List.of("url1", "url2"));
+
+        // 이미지 삭제 및 저장 확인
+        verify(imageRepository).deleteByTypeAndRefId(ImageType.FEED, feedId);
+        verify(imageRepository).saveAll(feed.getImageUrlList());
+
         assertThat(response.getFeedId()).isEqualTo(100L);
     }
 }


### PR DESCRIPTION
## 🔍 변경점
- 피드 수정 api 추가
- 피드 수정 service 테스트
- 피드 수정 시 예외 코드 추가
## 문제점

## 개선점

- s3 에서 기존 피드 이미지 삭제 로직 필요
- 수정 시 현재는 기존 이미지 다 삭제 후 리스트 전체 저장하는데 이게 최선인가 고민 필요
## ✅ PR 유형

- [X]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [X]  코드 리팩토링
- [ ]  문서 수정
- [X]  테스트 코드, 리팩토링 테스트 코드 추가
- [X]  파일 혹은 폴더명 수정
- [ ]  파일 삭제
- [X]  설정 파일 수정 및 추가
- [ ]  이미지나 동영상 추가
