### PR TITLE
[PR] 피드 상세 조회, 최신순 페이지네이션 api

### DIFF
--- a/toneup/src/main/java/com/threeboys/toneup/common/domain/Images.java
+++ b/toneup/src/main/java/com/threeboys/toneup/common/domain/Images.java
@@ -31,7 +31,7 @@ public class Images {
         this.s3Key = s3Key;
     }
 
-    public void changeProfileImageUrl(String url){
-        this.url = url;
+    public void changeProfileImageUrl(String s3Key){
+        this.s3Key = s3Key;
     }
 }

--- a/toneup/src/main/java/com/threeboys/toneup/feed/controller/FeedController.java
+++ b/toneup/src/main/java/com/threeboys/toneup/feed/controller/FeedController.java
@@ -3,11 +3,13 @@ package com.threeboys.toneup.feed.controller;
 import com.threeboys.toneup.common.response.StandardResponse;
 import com.threeboys.toneup.common.service.FileService;
 import com.threeboys.toneup.feed.dto.FeedDetailResponse;
+import com.threeboys.toneup.feed.dto.FeedPageItemResponse;
 import com.threeboys.toneup.feed.dto.FeedRequest;
 import com.threeboys.toneup.feed.dto.FeedResponse;
 import com.threeboys.toneup.feed.service.FeedService;
 import com.threeboys.toneup.security.CustomOAuth2User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.bind.DefaultValue;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -25,11 +27,17 @@ public class FeedController {
         return ResponseEntity.ok(new StandardResponse<>(true, 0, "ok",feedResponse));
     }
 
-    @GetMapping("/feed/{feedId}")
+    @GetMapping("/feeds/{feedId}")
     public ResponseEntity<?> getFeed(@PathVariable Long feedId, @AuthenticationPrincipal CustomOAuth2User customOAuth2User){
         Long userId = customOAuth2User.getId();
         FeedDetailResponse feedDetailResponse = feedService.getFeed(userId, feedId);
         return ResponseEntity.ok(new StandardResponse<>(true, 0, "ok",feedDetailResponse));
+    }
+    @GetMapping("/feeds")
+    public ResponseEntity<?> getFeed(@RequestParam(required = false) Long cursor, @RequestParam(defaultValue = "10") int limit, @AuthenticationPrincipal CustomOAuth2User customOAuth2User){
+        Long userId = customOAuth2User.getId();
+        FeedPageItemResponse feedPageItemResponse = feedService.getFeedPreviews(userId, cursor, limit);
+        return ResponseEntity.ok(new StandardResponse<>(true, 0, "ok",feedPageItemResponse));
     }
 
     @PutMapping("/feeds/{feedId}")

--- a/toneup/src/main/java/com/threeboys/toneup/feed/domain/Feed.java
+++ b/toneup/src/main/java/com/threeboys/toneup/feed/domain/Feed.java
@@ -32,6 +32,8 @@ public class Feed {
 
     private String content;
 
+    private int likeCount;
+
     @Transient
     private List<Images> imageUrlList = new ArrayList<>();
 

--- a/toneup/src/main/java/com/threeboys/toneup/feed/dto/FeedDetailDto.java
+++ b/toneup/src/main/java/com/threeboys/toneup/feed/dto/FeedDetailDto.java
@@ -12,18 +12,18 @@ public class FeedDetailDto {
     private String nickname;
     private String profileS3Key;
     private String feedImageS3Key;
-//    private int likeCount;
+    private int likeCount;
     private boolean isLiked;
 
     @QueryProjection
-    public FeedDetailDto(Long feedId, String content, Long userId, String nickname, String profileS3Key, String feedImageS3Key, boolean isLiked) {
+    public FeedDetailDto(Long feedId, String content, Long userId, String nickname, String profileS3Key, String feedImageS3Key,int likeCount, boolean isLiked) {
         this.feedId = feedId;
         this.content = content;
         this.userId = userId;
         this.nickname = nickname;
         this.profileS3Key = profileS3Key;
         this.feedImageS3Key = feedImageS3Key;
-//        this.likeCount = likeCount;
+        this.likeCount = likeCount;
         this.isLiked = isLiked;
     }
 }

--- a/toneup/src/main/java/com/threeboys/toneup/feed/dto/FeedDetailResponse.java
+++ b/toneup/src/main/java/com/threeboys/toneup/feed/dto/FeedDetailResponse.java
@@ -23,6 +23,7 @@ public class FeedDetailResponse {
                 .writer(new WriterResponse(feedDetailDto.getUserId(), feedDetailDto.getNickname(), profileUrl))
                 .content(feedDetailDto.getContent())
                 .createdAt(LocalDateTime.now())
+                .likeCount(feedDetailDto.getLikeCount())
                 .isLiked(feedDetailDto.isLiked())
                 .imageUrls(imageUrls)
                 .build();

--- a/toneup/src/main/java/com/threeboys/toneup/feed/dto/FeedPageItemResponse.java
+++ b/toneup/src/main/java/com/threeboys/toneup/feed/dto/FeedPageItemResponse.java
@@ -1,9 +1,13 @@
 package com.threeboys.toneup.feed.dto;
 
-import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 
+import java.util.List;
+@Data
+@AllArgsConstructor
 public class FeedPageItemResponse {
     private List<FeedPreviewResponse> feeds;
-    private int nextCursor;
+    private Long nextCursor;
     private boolean hasNext;
 }

--- a/toneup/src/main/java/com/threeboys/toneup/feed/dto/FeedPreviewResponse.java
+++ b/toneup/src/main/java/com/threeboys/toneup/feed/dto/FeedPreviewResponse.java
@@ -1,7 +1,10 @@
 package com.threeboys.toneup.feed.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
+import lombok.Data;
+import lombok.Getter;
 
+@Data
 public class FeedPreviewResponse {
     private Long feedId;
     private String imageUrl;

--- a/toneup/src/main/java/com/threeboys/toneup/feed/repository/CustomFeedRepository.java
+++ b/toneup/src/main/java/com/threeboys/toneup/feed/repository/CustomFeedRepository.java
@@ -1,6 +1,7 @@
 package com.threeboys.toneup.feed.repository;
 
 import com.threeboys.toneup.feed.dto.FeedDetailDto;
+import com.threeboys.toneup.feed.dto.FeedPageItemResponse;
 import com.threeboys.toneup.feed.dto.FeedPreviewResponse;
 import org.springframework.data.repository.query.Param;
 
@@ -8,5 +9,6 @@ import java.util.List;
 
 public interface CustomFeedRepository {
     List<FeedDetailDto> findFeedWithUserAndImageAndIsLiked(Long feedId, Long userId);
-    List<FeedPreviewResponse> findFeedPreviewsWithImageAndIsLiked(Long feedId, Long userId, Long cursor, int pageSize);
+
+    FeedPageItemResponse findFeedPreviewsWithImageAndIsLiked(Long userId, Long cursor, int pageSize);
 }

--- a/toneup/src/main/java/com/threeboys/toneup/feed/service/FeedService.java
+++ b/toneup/src/main/java/com/threeboys/toneup/feed/service/FeedService.java
@@ -83,15 +83,23 @@ public class FeedService {
         return FeedDetailResponse.from(feedDetailDtoList.getFirst(), profileImageUrl,imageUrls);
     }
 
-//    public FeedPageItemResponse getFeedPreviews(Long userId , Long feedId, Long cursor, int limit) {
-//        //다중 조인으로 전체 조회(프로필, 피드 ,이미지들, 좋아요여부)
-//        List<FeedPreviewResponse> feedPreviewResponseList = feedRepository.findFeedPreviewsWithImageAndIsLiked(feedId, userId, cursor, limit);
-//        // 이미지 s3Key로 s3 조회해서 url 획득 + 프로필 이미지도 획득
-//        List<String> imageUrls = feedDetailDtoList.stream()
-//                .map(feedDetailDto -> fileService.getPreSignedUrl(feedDetailDto.getFeedImageS3Key()))
-//                .toList();
-//        String profileImageUrl = fileService.getPreSignedUrl(feedDetailDtoList.getFirst().getProfileS3Key());
-//
-//        return new FeedPageItemResponse();
-//    }
+    public FeedPageItemResponse getFeedPreviews(Long userId , Long cursor, int limit) {
+        //다중 조인으로 전체 조회(프로필, 피드 ,이미지들, 좋아요여부)
+        FeedPageItemResponse feedPageItemResponse = feedRepository.findFeedPreviewsWithImageAndIsLiked( userId, cursor, limit);
+        // 이미지 s3Key로 s3 조회해서 url 획득 + 프로필 이미지도 획득  
+        feedPageItemResponse.getFeeds().forEach(feedPreviewResponse -> {
+            feedPreviewResponse.setImageUrl(fileService.getPreSignedUrl(feedPreviewResponse.getImageUrl()));
+        });
+        return feedPageItemResponse;
+    }
+
+    public FeedPageItemResponse getRankingFeedPreviews(Long userId , Long cursor, int limit) {
+        //다중 조인으로 전체 조회(프로필, 피드 ,이미지들, 좋아요여부)
+        FeedPageItemResponse feedPageItemResponse = feedRepository.findFeedPreviewsWithImageAndIsLiked( userId, cursor, limit);
+        // 이미지 s3Key로 s3 조회해서 url 획득 + 프로필 이미지도 획득
+        feedPageItemResponse.getFeeds().forEach(feedPreviewResponse -> {
+            feedPreviewResponse.setImageUrl(fileService.getPreSignedUrl(feedPreviewResponse.getImageUrl()));
+        });
+        return feedPageItemResponse;
+    }
 }

--- a/toneup/src/main/java/com/threeboys/toneup/personalColor/controller/PersonalColorController.java
+++ b/toneup/src/main/java/com/threeboys/toneup/personalColor/controller/PersonalColorController.java
@@ -46,8 +46,7 @@ public class PersonalColorController {
             Thread.sleep(4000);
             UserEntity user = userRepository.findById(userId).orElseThrow();
             PersonalColor personalColor1 = PersonalColor.builder().personalColorType(PersonalColorType.ATUMN).build();
-            personalColorRepository.save(personalColor1);
-            PersonalColor personalColorEntity = personalColorRepository.findById(1).orElseThrow();
+            PersonalColor personalColorEntity= personalColorRepository.save(personalColor1);
             user.updatePersonalColor(personalColorEntity);
             personalColor = personalColorEntity.getPersonalColorType().toString();
         }catch (InterruptedException e){

--- a/toneup/src/main/java/com/threeboys/toneup/security/service/GoogleLoginService.java
+++ b/toneup/src/main/java/com/threeboys/toneup/security/service/GoogleLoginService.java
@@ -58,7 +58,7 @@ public class GoogleLoginService implements OAuthLoginService{
             String providerId =  payload.getSubject();
             String nickname = name+"_"+providerId;
 
-            // 3. (예시) 회원 가입 또는 로그인 처리 (생략 가능)
+            // 3. 회원 가입 또는 로그인 처리
             UserEntity socialUser = userservice.registerUser(name,nickname, email, providerType, providerId);
             String personalColorType = (socialUser.getPersonalColor()==null) ? null : socialUser.getPersonalColor().getPersonalColorType().toString();
 

--- a/toneup/src/main/java/com/threeboys/toneup/user/entity/UserEntity.java
+++ b/toneup/src/main/java/com/threeboys/toneup/user/entity/UserEntity.java
@@ -37,7 +37,7 @@ public class UserEntity {
     private String email;
 
     @OneToOne(fetch = FetchType.EAGER,cascade = CascadeType.ALL)
-    @JoinColumn(name = "profile_image_id")
+    @JoinColumn(name = "profile_image_id", unique = false)
     private Images profileImageId;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -90,5 +90,11 @@ public class UserEntity {
         this.nickname  = user.getNickname();
         this.bio =user.getBio();
         this.profileImageId.changeProfileImageUrl(user.getProfileImageUrl());
+    }
+
+    public void changeProfileCreateImage(User user, Images image) {
+        this.nickname  = user.getNickname();
+        this.bio =user.getBio();
+        this.profileImageId = image;
     }
 }

--- a/toneup/src/main/java/com/threeboys/toneup/user/service/Userservice.java
+++ b/toneup/src/main/java/com/threeboys/toneup/user/service/Userservice.java
@@ -1,6 +1,7 @@
 package com.threeboys.toneup.user.service;
 
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.threeboys.toneup.common.domain.ImageType;
 import com.threeboys.toneup.common.domain.Images;
 import com.threeboys.toneup.common.repository.ImageRepository;
 import com.threeboys.toneup.common.service.FileService;
@@ -23,6 +24,7 @@ public class Userservice {
     private final ImageRepository imageRepository;
     private final FileService fileService;
 
+    private static final String DEFAULT_PROFILE_IMAGE ="images/DEFAULT_PROFILE_IMAGE";
     public UserEntity registerUser(String name, String nickname, String email, ProviderType providerType, String providerId){
         return userRepository.findByProviderAndProviderId(providerType,providerId)
 //                .map(userEntity -> {
@@ -34,8 +36,14 @@ public class Userservice {
                 .orElseGet(() -> {
                     // 기본 프로필 이미지 추가(기본 프로필 이미지 id = 0)
                     // 이미지 없을때 예외 처리 해야하나
-                    Images profileImage = new Images();
-//                    Images profileImage = imageRepository.findById(0L).orElseThrow();
+                    Images profileImage = Images.builder()
+                        .url(DEFAULT_PROFILE_IMAGE)
+                        .type(ImageType.PROFILE)
+//                        .refId()
+                        .order(0)
+                        .s3Key(DEFAULT_PROFILE_IMAGE)
+                        .build();
+
                     // 회원가입
                     UserEntity newUser = new UserEntity(name,nickname, providerType, providerId, email, profileImage);
                     return userRepository.save(newUser);
@@ -62,6 +70,7 @@ public class Userservice {
     public void updateProfile(Long userId, UpdateProfileRequest updateProfileRequest) {
         UserEntity userEntity = userRepository.findById(userId).orElseThrow(()->new UserNotFoundException(userId));
         User user = userEntity.toDomain();
+        System.out.println(userEntity.getProfileImageId());
         Long profileId = userEntity.getProfileImageId().getId();
         String s3Key = userEntity.getProfileImageId().getS3Key();
         //Mapper로 변경 고려 필요? or changeProfile 안에 넣기?
@@ -70,9 +79,23 @@ public class Userservice {
         if(updateProfileRequest.getProfileImageUrl()!=null) user.changeProfileImage(updateProfileRequest.getProfileImageUrl());
 
         //s3 기존 이미지 삭제 필요?(기본 이미지였던 경우에는 제외) fileService.changeProfileImage(?)
-        if(profileId!=0)fileService.deleteS3Object(s3Key);
+        //기본 프로필 이미지가 아닌 경우 현재 이미지 엔티티 s3Key값만 수정
+        if(!userEntity.getProfileImageId().getS3Key().equals(DEFAULT_PROFILE_IMAGE)) fileService.deleteS3Object(s3Key);
+
+        userEntity.changeProfile(user);
+
+//        Images image = userEntity.getProfileImageId();
+//        image.changeProfileImageUrl(user.getProfileImageUrl());
 
         //더티 체킹으로 이미지 url 변경
-        userEntity.changeProfile(user);
+//        Images image = Images.builder()
+//                .url(user.getProfileImageUrl())
+//                .type(ImageType.PROFILE)
+//                .refId(userId)
+//                .order(0)
+//                .s3Key(user.getProfileImageUrl())
+//                .build();
+
+
     }
 }


### PR DESCRIPTION
## 🔍 변경점
- 피드 상세 조회, 최신순 페이지네이션 api
- 피드 조회를 위한 like 테이블 추가
- 회원 가입시 기본 프로필 이미지 지정을 통해 프로필 수정 시 발생되는 문제 해결
## 문제점

## 개선점

- 좋아요순 정렬 시 likeCount를 feed 테이블에 반정규화 하였는데 따로 통계 테이블로 빼는게 맞는가 고민 필요
- 피드 페이지네이션, 조회 등 api 테스트 코드  구현 필요

## ✅ PR 유형

- [X]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [X]  코드 리팩토링
- [ ]  문서 수정
- [ ]  테스트 코드, 리팩토링 테스트 코드 추가
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 삭제
- [X]  설정 파일 수정 및 추가
- [ ]  이미지나 동영상 추가
