### PR TITLE
[PR] 피드 랭킹순 페이지네이션 api 쿼리 및 컨트롤러, 서비스, dto 수정 

### DIFF
--- a/toneup/src/main/java/com/threeboys/toneup/feed/controller/FeedController.java
+++ b/toneup/src/main/java/com/threeboys/toneup/feed/controller/FeedController.java
@@ -2,10 +2,7 @@ package com.threeboys.toneup.feed.controller;
 
 import com.threeboys.toneup.common.response.StandardResponse;
 import com.threeboys.toneup.common.service.FileService;
-import com.threeboys.toneup.feed.dto.FeedDetailResponse;
-import com.threeboys.toneup.feed.dto.FeedPageItemResponse;
-import com.threeboys.toneup.feed.dto.FeedRequest;
-import com.threeboys.toneup.feed.dto.FeedResponse;
+import com.threeboys.toneup.feed.dto.*;
 import com.threeboys.toneup.feed.service.FeedService;
 import com.threeboys.toneup.security.CustomOAuth2User;
 import lombok.RequiredArgsConstructor;
@@ -28,18 +25,23 @@ public class FeedController {
     }
 
     @GetMapping("/feeds/{feedId}")
-    public ResponseEntity<?> getFeed(@PathVariable Long feedId, @AuthenticationPrincipal CustomOAuth2User customOAuth2User){
+    public ResponseEntity<?> getFeedDetail(@PathVariable Long feedId, @AuthenticationPrincipal CustomOAuth2User customOAuth2User){
         Long userId = customOAuth2User.getId();
         FeedDetailResponse feedDetailResponse = feedService.getFeed(userId, feedId);
         return ResponseEntity.ok(new StandardResponse<>(true, 0, "ok",feedDetailResponse));
     }
     @GetMapping("/feeds")
-    public ResponseEntity<?> getFeed(@RequestParam(required = false) Long cursor, @RequestParam(defaultValue = "10") int limit, @AuthenticationPrincipal CustomOAuth2User customOAuth2User){
+    public ResponseEntity<?> getFeedPagination(@RequestParam(required = false) Long cursor, @RequestParam(defaultValue = "10") int limit, @AuthenticationPrincipal CustomOAuth2User customOAuth2User){
         Long userId = customOAuth2User.getId();
         FeedPageItemResponse feedPageItemResponse = feedService.getFeedPreviews(userId, cursor, limit);
         return ResponseEntity.ok(new StandardResponse<>(true, 0, "ok",feedPageItemResponse));
     }
-
+    @GetMapping("/rankingfeeds")
+    public ResponseEntity<?> getFeedRankingPagination(@RequestParam(required = false) String cursor, @RequestParam(defaultValue = "10") int limit, @AuthenticationPrincipal CustomOAuth2User customOAuth2User){
+        Long userId = customOAuth2User.getId();
+        FeedRankingPageItemResponse feedRankingPageItemResponse = feedService.getRankingFeedPreviews(userId, cursor, limit);
+        return ResponseEntity.ok(new StandardResponse<>(true, 0, "ok",feedRankingPageItemResponse));
+    }
     @PutMapping("/feeds/{feedId}")
     public ResponseEntity<?> updateFeed(@PathVariable Long feedId, @RequestBody FeedRequest feedRequest, @AuthenticationPrincipal CustomOAuth2User customOAuth2User){
         Long userId = customOAuth2User.getId();

--- a/toneup/src/main/java/com/threeboys/toneup/feed/dto/FeedRankingPageItemResponse.java
+++ b/toneup/src/main/java/com/threeboys/toneup/feed/dto/FeedRankingPageItemResponse.java
@@ -1,0 +1,13 @@
+package com.threeboys.toneup.feed.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+@AllArgsConstructor
+@Data
+public class FeedRankingPageItemResponse{
+    private List<FeedPreviewResponse> feeds;
+    private String nextCursor;
+    private boolean hasNext;
+}

--- a/toneup/src/main/java/com/threeboys/toneup/feed/repository/CustomFeedRepository.java
+++ b/toneup/src/main/java/com/threeboys/toneup/feed/repository/CustomFeedRepository.java
@@ -3,6 +3,7 @@ package com.threeboys.toneup.feed.repository;
 import com.threeboys.toneup.feed.dto.FeedDetailDto;
 import com.threeboys.toneup.feed.dto.FeedPageItemResponse;
 import com.threeboys.toneup.feed.dto.FeedPreviewResponse;
+import com.threeboys.toneup.feed.dto.FeedRankingPageItemResponse;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
@@ -11,4 +12,7 @@ public interface CustomFeedRepository {
     List<FeedDetailDto> findFeedWithUserAndImageAndIsLiked(Long feedId, Long userId);
 
     FeedPageItemResponse findFeedPreviewsWithImageAndIsLiked(Long userId, Long cursor, int pageSize);
+
+    FeedRankingPageItemResponse findRankingFeedPreviewsWithImageAndIsLiked(Long userId, String cursor, int limit);
+
 }

--- a/toneup/src/main/java/com/threeboys/toneup/feed/service/FeedService.java
+++ b/toneup/src/main/java/com/threeboys/toneup/feed/service/FeedService.java
@@ -93,13 +93,13 @@ public class FeedService {
         return feedPageItemResponse;
     }
 
-    public FeedPageItemResponse getRankingFeedPreviews(Long userId , Long cursor, int limit) {
+    public FeedRankingPageItemResponse getRankingFeedPreviews(Long userId , String cursor, int limit) {
         //다중 조인으로 전체 조회(프로필, 피드 ,이미지들, 좋아요여부)
-        FeedPageItemResponse feedPageItemResponse = feedRepository.findFeedPreviewsWithImageAndIsLiked( userId, cursor, limit);
+        FeedRankingPageItemResponse feedRankingPageItemResponse = feedRepository.findRankingFeedPreviewsWithImageAndIsLiked( userId, cursor, limit);
         // 이미지 s3Key로 s3 조회해서 url 획득 + 프로필 이미지도 획득
-        feedPageItemResponse.getFeeds().forEach(feedPreviewResponse -> {
+        feedRankingPageItemResponse.getFeeds().forEach(feedPreviewResponse -> {
             feedPreviewResponse.setImageUrl(fileService.getPreSignedUrl(feedPreviewResponse.getImageUrl()));
         });
-        return feedPageItemResponse;
+        return feedRankingPageItemResponse;
     }
 }


### PR DESCRIPTION
## 🔍 변경점
- 피드 랭킹순 페이지네이션 api 쿼리 및 컨트롤러, 서비스, dto 수정
## 문제점

## 개선점

- 랭킹 페이지네이션 cursor 예외 처리 부분 수정 필요(마지막 페이지네이션일때 값이 null 이거나 애초에 의도적으로 잘못된 cursor 보내는 경우 처리 필요)
- 테스트 필요

## ✅ PR 유형

- [X]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드 리팩토링
- [ ]  문서 수정
- [ ]  테스트 코드, 리팩토링 테스트 코드 추가
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 삭제
- [ ]  설정 파일 수정 및 추가
- [ ]  이미지나 동영상 추가
