### PR TITLE
[PR] 분산락 이용한 피드, 상품 좋아요 api 기능 구현

### DIFF
--- a/toneup/src/main/java/com/threeboys/toneup/common/config/RedissonConfig.java
+++ b/toneup/src/main/java/com/threeboys/toneup/common/config/RedissonConfig.java
@@ -10,6 +10,8 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class RedissonConfig {
 
+    public static final String REDISSON_HOST_PREFIX = "redis://";
+
     @Value("${spring.data.redis.host}")
     private String redisHost;
 
@@ -20,7 +22,7 @@ public class RedissonConfig {
     public RedissonClient redissonClient() {
         Config config = new Config();
         config.useSingleServer()
-                .setAddress("redis://" + redisHost + ":" + redisPort);
+                .setAddress(REDISSON_HOST_PREFIX + redisHost + ":" + redisPort);
         return Redisson.create(config);
     }
 }

--- a/toneup/src/main/java/com/threeboys/toneup/common/response/exception/ErrorMessages.java
+++ b/toneup/src/main/java/com/threeboys/toneup/common/response/exception/ErrorMessages.java
@@ -17,4 +17,5 @@ public class ErrorMessages {
     public static final String TOKEN_EXPIRED = "토큰이 만료되었습니다.";
     public static final String INVALID_NICKNAME_FORMAT = "닉네임은 2~20자 이내, 특수문자 없이 입력해주세요.";
     public static final String NICKNAME_ALREADY_EXISTS = "이미 사용 중인 닉네임입니다.";
+    public static final String PRODUCT_NOT_FOUND = "상품을 찾을 수 없습니다.";
 }

--- a/toneup/src/main/java/com/threeboys/toneup/feed/domain/Feed.java
+++ b/toneup/src/main/java/com/threeboys/toneup/feed/domain/Feed.java
@@ -42,6 +42,7 @@ public class Feed {
         validateContent(content);
         this.userId = user;
         this.content = content;
+        this.likeCount = 0;
     }
 
     public void attachImages(List<String> imageUrls){

--- a/toneup/src/main/java/com/threeboys/toneup/like/annotation/DistributedLock.java
+++ b/toneup/src/main/java/com/threeboys/toneup/like/annotation/DistributedLock.java
@@ -1,0 +1,34 @@
+package com.threeboys.toneup.like.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+
+    /**
+     * 락의 이름
+     */
+    String key();
+
+    /**
+     * 락의 시간 단위
+     */
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+    /**
+     * 락을 기다리는 시간 (default - 5s)
+     * 락 획득을 위해 waitTime 만큼 대기한다
+     */
+    long waitTime() default 2L;
+
+    /**
+     * 락 임대 시간 (default - 3s)
+     * 락을 획득한 이후 leaseTime 이 지나면 락을 해제한다
+     */
+    long leaseTime() default 3L;
+}

--- a/toneup/src/main/java/com/threeboys/toneup/like/aop/AopForTransaction.java
+++ b/toneup/src/main/java/com/threeboys/toneup/like/aop/AopForTransaction.java
@@ -1,0 +1,18 @@
+package com.threeboys.toneup.like.aop;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * AOP에서 트랜잭션 분리를 위한 클래스
+ */
+@Component
+public class AopForTransaction {
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Object proceed(final ProceedingJoinPoint joinPoint) throws Throwable {
+        return joinPoint.proceed();
+    }
+}

--- a/toneup/src/main/java/com/threeboys/toneup/like/aop/DistributedLockAop.java
+++ b/toneup/src/main/java/com/threeboys/toneup/like/aop/DistributedLockAop.java
@@ -1,0 +1,59 @@
+package com.threeboys.toneup.like.aop;
+
+import com.threeboys.toneup.like.annotation.DistributedLock;
+import com.threeboys.toneup.like.parser.CustomSpringELParser;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+/**
+ * @DistributedLock 선언 시 수행되는 Aop class
+ */
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DistributedLockAop {
+    private static final String REDISSON_LOCK_PREFIX = "LOCK:";
+
+    private final RedissonClient redissonClient;
+    private final AopForTransaction aopForTransaction;
+
+    @Around("@annotation(com.threeboys.toneup.like.annotation.DistributedLock)")
+    public Object lock(final ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        DistributedLock distributedLock = method.getAnnotation(DistributedLock.class);
+
+        String key = REDISSON_LOCK_PREFIX + CustomSpringELParser.getDynamicValue(signature.getParameterNames(), joinPoint.getArgs(), distributedLock.key());
+        RLock rLock = redissonClient.getLock(key);  // (1)
+
+        try {
+            boolean available = rLock.tryLock(distributedLock.waitTime(), distributedLock.leaseTime(), distributedLock.timeUnit());  // (2)
+            if (!available) {
+                return false;
+            }
+
+            return aopForTransaction.proceed(joinPoint);  // (3)
+        } catch (InterruptedException e) {
+            throw new InterruptedException();
+        } finally {
+            try {
+                rLock.unlock();   // (4)
+            } catch (IllegalMonitorStateException e) {
+                log.info("Redisson Lock Already UnLock {} {}",
+                        method.getName(),
+                        key
+                );
+            }
+        }
+    }
+}

--- a/toneup/src/main/java/com/threeboys/toneup/like/domain/ProductsLike.java
+++ b/toneup/src/main/java/com/threeboys/toneup/like/domain/ProductsLike.java
@@ -5,6 +5,7 @@ import com.threeboys.toneup.product.domain.Product;
 import com.threeboys.toneup.user.entity.UserEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 @Entity
@@ -22,4 +23,10 @@ public class ProductsLike {
     @ManyToOne(fetch = FetchType.LAZY,optional = false)
     @JoinColumn(name = "user_id")
     private UserEntity user;
+
+    @Builder
+    public ProductsLike(Product product, UserEntity user) {
+        this.product = product;
+        this.user = user;
+    }
 }

--- a/toneup/src/main/java/com/threeboys/toneup/like/parser/CustomSpringELParser.java
+++ b/toneup/src/main/java/com/threeboys/toneup/like/parser/CustomSpringELParser.java
@@ -1,0 +1,24 @@
+package com.threeboys.toneup.like.parser;
+
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+/**
+ * Spring Expression Language Parser
+ */
+public class CustomSpringELParser {
+    private CustomSpringELParser() {
+    }
+
+    public static Object getDynamicValue(String[] parameterNames, Object[] args, String key) {
+        ExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        return parser.parseExpression(key).getValue(context, Object.class);
+    }
+}

--- a/toneup/src/main/java/com/threeboys/toneup/like/repository/FeedsLikeRepository.java
+++ b/toneup/src/main/java/com/threeboys/toneup/like/repository/FeedsLikeRepository.java
@@ -2,10 +2,14 @@ package com.threeboys.toneup.like.repository;
 
 import com.threeboys.toneup.like.domain.FeedsLike;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface FeedsLikeRepository extends JpaRepository<FeedsLike, Long> {
 
     boolean existsByFeedIdAndUserId(Long feedId, Long userId);
 
     void deleteByFeedIdAndUserId(Long feedId, Long userId);
+
+    void deleteAllByFeedId(Long testFeedId);
 }

--- a/toneup/src/main/java/com/threeboys/toneup/like/repository/ProductsLikeRepository.java
+++ b/toneup/src/main/java/com/threeboys/toneup/like/repository/ProductsLikeRepository.java
@@ -2,6 +2,13 @@ package com.threeboys.toneup.like.repository;
 
 import com.threeboys.toneup.like.domain.ProductsLike;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ProductsLikeRepository extends JpaRepository<ProductsLike, Long> {
+    boolean existsByProductIdAndUserId(Long productId, Long userId);
+
+    void deleteByProductIdAndUserId(Long productId, Long userId);
+
+   long countByProductId(Long testProductId);
 }

--- a/toneup/src/main/java/com/threeboys/toneup/like/service/LikeService.java
+++ b/toneup/src/main/java/com/threeboys/toneup/like/service/LikeService.java
@@ -3,17 +3,24 @@ package com.threeboys.toneup.like.service;
 import com.threeboys.toneup.feed.domain.Feed;
 import com.threeboys.toneup.feed.exception.FeedNotFoundException;
 import com.threeboys.toneup.feed.repository.FeedRepository;
+import com.threeboys.toneup.like.annotation.DistributedLock;
 import com.threeboys.toneup.like.domain.FeedsLike;
+import com.threeboys.toneup.like.domain.ProductsLike;
 import com.threeboys.toneup.like.repository.FeedsLikeRepository;
 import com.threeboys.toneup.like.repository.ProductsLikeRepository;
+import com.threeboys.toneup.product.domain.Product;
+import com.threeboys.toneup.product.exception.ProductNotFoundException;
+import com.threeboys.toneup.product.repository.ProductRepository;
 import com.threeboys.toneup.user.entity.UserEntity;
 import com.threeboys.toneup.user.repository.UserRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronizationAdapter;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.concurrent.TimeUnit;
 @Slf4j
@@ -21,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class LikeService {
     private final FeedRepository feedRepository;
+    private final ProductRepository productRepository;
     private final UserRepository userRepository;
 
     private final FeedsLikeRepository feedsLikeRepository;
@@ -35,14 +43,66 @@ public class LikeService {
         final RLock lock = redissonClient.getLock(lockName);
         try{
             //redisson 분산락 획득
-            if(!lock.tryLock(1,3, TimeUnit.SECONDS)) return;
+            if(!lock.tryLock(2,3, TimeUnit.SECONDS)) {
+                throw new RuntimeException("lock 획득 실패!!!");
+            }
 
+            boolean isLiked = feedsLikeRepository.existsByFeedIdAndUserId(feedId, userId);
+            //좋아요 테이블에 존재하면 삭제 후 피드 테이블 likeCount - 1
+            Feed feed = feedRepository.findById(feedId).orElseThrow(FeedNotFoundException::new);
+            if(isLiked){
+//                feedRepository.flush();
+                feedsLikeRepository.deleteByFeedIdAndUserId(feedId, userId);
+                feed.decreaseLikeCount();
+
+//                feedsLikeRepository.flush();
+            }else{ //좋아요 테이블에 존재하지 않으면 추가 후 피드 테이블 likeCount + 1
+                UserEntity user = userRepository.getReferenceById(userId);
+                FeedsLike feedsLike = FeedsLike.builder()
+                        .feed(feed)
+                        .user(user)
+                        .build();
+//                feedRepository.flush();
+                feedsLikeRepository.save(feedsLike);
+                feed.increaseLikeCount();
+
+//                feedsLikeRepository.flush();
+            }
+
+
+
+            // 트랜잭션 커밋 이후에 락 해제
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronizationAdapter() {
+                @Override
+                public void afterCommit() {
+                    if (lock.isHeldByCurrentThread()) {
+                        lock.unlock();
+                    }
+                }
+            });
+
+        }catch (InterruptedException ex){
+//            Thread.currentThread().interrupt(); //사용 이유 다시 알아보기
+            log.error(ex.getMessage());
+        }
+//        finally {
+//            if(lock != null && lock.isHeldByCurrentThread()) {
+//                lock.unlock();
+//            }
+//        }
+
+    }
+    //aop 적용
+//    @Transactional
+    @DistributedLock(key = "FEED"+"_"+"#feedId")
+    public void feedToggleLike(Long feedId, Long userId){
             boolean isLiked = feedsLikeRepository.existsByFeedIdAndUserId(feedId, userId);
             //좋아요 테이블에 존재하면 삭제 후 피드 테이블 likeCount - 1
             Feed feed = feedRepository.findById(feedId).orElseThrow(FeedNotFoundException::new);
             if(isLiked){
                 feedsLikeRepository.deleteByFeedIdAndUserId(feedId, userId);
                 feed.decreaseLikeCount();
+
             }else{ //좋아요 테이블에 존재하지 않으면 추가 후 피드 테이블 likeCount + 1
                 UserEntity user = userRepository.getReferenceById(userId);
                 FeedsLike feedsLike = FeedsLike.builder()
@@ -52,13 +112,26 @@ public class LikeService {
                 feedsLikeRepository.save(feedsLike);
                 feed.increaseLikeCount();
             }
-        }catch (InterruptedException ex){
-//            Thread.currentThread().interrupt(); //사용 이유 다시 알아보기
-            log.error(ex.getMessage());
-        }finally {
-            if(lock != null && lock.isHeldByCurrentThread()) {
-                lock.unlock();
-            }
+
+    }
+//    @Transactional
+    //굳이 분산락 필요한가 동일 유저가 동시 요청을 하는 경우가 많지 않을꺼 같은데 낙관락 적용해도 되지 않나
+    @DistributedLock(key = "'PRODUCT_' + #productId + '_' + #userId")
+    public void productToggleLike(Long productId, Long userId){
+        boolean isLiked = productsLikeRepository.existsByProductIdAndUserId(productId, userId);
+
+        Product product = productRepository.findById(productId).orElseThrow(ProductNotFoundException::new);
+        //좋아요 테이블에 존재하면 삭제
+        if(isLiked){
+            productsLikeRepository.deleteByProductIdAndUserId(productId, userId);
+
+        }else{ //좋아요 테이블에 존재하지 않으면 추가
+            UserEntity user = userRepository.getReferenceById(userId);
+            ProductsLike productsLike = ProductsLike.builder()
+                    .product(product)
+                    .user(user)
+                    .build();
+            productsLikeRepository.save(productsLike);
         }
 
     }

--- a/toneup/src/main/java/com/threeboys/toneup/product/exception/ProductNotFoundException.java
+++ b/toneup/src/main/java/com/threeboys/toneup/product/exception/ProductNotFoundException.java
@@ -1,0 +1,9 @@
+package com.threeboys.toneup.product.exception;
+
+import com.threeboys.toneup.common.response.exception.ErrorMessages;
+
+public class ProductNotFoundException extends RuntimeException {
+    public ProductNotFoundException() {
+        super(ErrorMessages.PRODUCT_NOT_FOUND);
+    }
+}

--- a/toneup/src/main/java/com/threeboys/toneup/product/repository/ProductRepository.java
+++ b/toneup/src/main/java/com/threeboys/toneup/product/repository/ProductRepository.java
@@ -1,0 +1,9 @@
+package com.threeboys.toneup.product.repository;
+
+import com.threeboys.toneup.product.domain.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductRepository extends JpaRepository<Product, Long> {
+}

--- a/toneup/src/main/java/com/threeboys/toneup/user/repository/UserRepository.java
+++ b/toneup/src/main/java/com/threeboys/toneup/user/repository/UserRepository.java
@@ -12,4 +12,6 @@ public interface UserRepository extends JpaRepository<UserEntity,Long> {
     Optional<UserEntity> findByEmail(String mail);
     Optional<UserEntity> findByNickname(String nickname);
     Optional<UserEntity> findByProviderAndProviderId(ProviderType provider, String providerId);
+
+    void deleteAllByNameStartingWith(String likeTestUser);
 }

--- a/toneup/src/test/java/com/threeboys/toneup/like/likeRLockTest.java
+++ b/toneup/src/test/java/com/threeboys/toneup/like/likeRLockTest.java
@@ -1,0 +1,149 @@
+package com.threeboys.toneup.like;
+
+import com.threeboys.toneup.common.domain.ImageType;
+import com.threeboys.toneup.common.domain.Images;
+import com.threeboys.toneup.common.repository.ImageRepository;
+import com.threeboys.toneup.feed.domain.Feed;
+import com.threeboys.toneup.feed.repository.FeedRepository;
+import com.threeboys.toneup.like.repository.FeedsLikeRepository;
+import com.threeboys.toneup.like.repository.ProductsLikeRepository;
+import com.threeboys.toneup.like.service.LikeService;
+import com.threeboys.toneup.product.repository.ProductRepository;
+import com.threeboys.toneup.security.provider.ProviderType;
+import com.threeboys.toneup.user.entity.UserEntity;
+import com.threeboys.toneup.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+public class likeRLockTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private FeedRepository feedRepository;
+
+
+    @Autowired
+    private ImageRepository imageRepository;
+
+    @Autowired
+    private FeedsLikeRepository feedsLikeRepository;
+
+    @Autowired
+    private ProductsLikeRepository productsLikeRepository;
+
+    @Autowired
+    private LikeService likeService;
+
+
+
+    private Long testFeedId;
+    private Long testStartUserId;
+    private final int TestUserCount=50;
+    private final Long testProductUser = 1L;
+    public static final Long testProductId = 1L;
+
+    @BeforeEach
+//    @Transactional
+    void setUp(){
+        UserEntity user = userRepository.findById(1L).orElseThrow();
+        Feed feed = Feed.builder().content("Like Test Feed").user(user).build();
+        feedRepository.save(feed);
+        testFeedId = feed.getId();
+
+
+        for(long i=0; i<TestUserCount; i++){
+            Images images = Images.builder()
+                    .type(ImageType.PROFILE)
+                    .order(0)
+                    .s3Key("images/DEFAULT_PROFILE_IMAGE")
+                    .build();
+
+            UserEntity testUser = new UserEntity("likeTestUser"+i, "userNickname"+i, ProviderType.GOOGLE, "testProviderId" +i, "testEmail"+i+"@test.com",images);
+            userRepository.save(testUser);
+            if(i==0) testStartUserId = testUser.getId();
+        }
+
+        System.out.println("testStartUserId : " + testStartUserId);
+    }
+
+    @Test
+    @DisplayName("피드 좋아요 api service 메서드 redisson 분산락 테스트")
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void toggleFeedLikeTestWithRLock() throws InterruptedException {
+        int threadCount = TestUserCount;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (long i = 1; i <= threadCount; i++) {
+            final long userIdIdx = i;
+            executor.submit(() -> {
+                try {
+//                    likeService.feedLike(testFeedId, testStartUserId-1 + userIdIdx); // 여기서 그대로 사용
+                    likeService.feedToggleLike(testFeedId, testStartUserId-1 + userIdIdx); // 여기서 그대로 사용
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executor.shutdown();
+
+        Feed afterFeed = feedRepository.findById(testFeedId).orElseThrow();
+        int totalLikeCount = afterFeed.getLikeCount();
+        assertThat(totalLikeCount).isEqualTo(TestUserCount);
+    }
+
+    @Test
+    @DisplayName("상품 좋아요 api service 메서드 redisson 분산락 테스트(동일 유저가 동시 요청 시)")
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void toggleProductLikeTestWithRLock() throws InterruptedException {
+        int threadCount = TestUserCount;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (long i = 0; i < threadCount; i++) {
+            final long userIdIdx = i;
+            executor.submit(() -> {
+                try {
+                    likeService.productToggleLike(testProductId, testProductUser);//testStartUserId + userIdIdx
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executor.shutdown();
+
+//        long ProductlikeCount = productsLikeRepository.countByProductId(testProductId);
+//        assertThat(ProductlikeCount).isEqualTo(TestUserCount);
+        long ProductlikeCount = productsLikeRepository.countByProductId(testProductId);
+        assertThat(ProductlikeCount).isEqualTo(threadCount%2);
+
+    }
+
+//    @AfterEach
+//    @Transactional
+//    void cleanUp() throws InterruptedException {
+//        Thread.sleep(2000);
+//        feedsLikeRepository.deleteAllByFeedId(testFeedId);
+//        userRepository.deleteAllByNameStartingWith("likeTestUser");
+//        feedRepository.deleteById(testFeedId);
+//    }
+}


### PR DESCRIPTION
## 🔍 변경점
- 분산락 위한 redisson 및 의존성 추가
- likeService 메서드 테스트 구현
- redissonConfig 매직 스트링 제거
- 제품 조회 불가 예외 처리
## 문제점

## 개선점

- 상품 좋아요는 좋아요 수가 필요없고 동시성 문제는 동일 유저가 동시에 요청을 보내는 경우에만 발생되므로 유니크 처리와 낙관락 적용이 더 효율적일꺼 같다.
- 분산 서버에서 진짜 테스트 필요
- 좋아요 api 두개로 분리 하는거랑 어떤 차이가 (장단점이 있나) 깊게 생각해보자 헷갈림

## ✅ PR 유형

- [X]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [X]  코드 리팩토링
- [ ]  문서 수정
- [X]  테스트 코드, 리팩토링 테스트 코드 추가
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 삭제
- [X]  설정 파일 수정 및 추가
- [ ]  이미지나 동영상 추가
